### PR TITLE
allow relative paths in @resurrect-dir

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -131,10 +131,10 @@ dump_bash_history() {
 save_all() {
 	local resurrect_file_path="$(resurrect_file_path)"
 	mkdir -p "$(resurrect_dir)"
-	dump_panes   >  $resurrect_file_path
-	dump_windows >> $resurrect_file_path
-	dump_state   >> $resurrect_file_path
-	ln -fs "$resurrect_file_path" "$(last_resurrect_file)"
+	dump_panes   >  "$resurrect_file_path"
+	dump_windows >> "$resurrect_file_path"
+	dump_state   >> "$resurrect_file_path"
+	ln -fs "$(basename "$resurrect_file_path")" "$(last_resurrect_file)"
 	if save_bash_history_option_on; then
 		dump_bash_history
 	fi


### PR DESCRIPTION
this has been tested to work with set -g @resurrect-dir '.tmux/resu rrect'

previous code didn't seem to work when resurrect-dir had spaces
