### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ is present.
 By default Tmux environment is saved to a file in `~/.tmux/resurrect` dir.
 Change this with:
 
-    set -g @resurrect-dir '/some/path'
+    set -g @resurrect-dir /some/path
 
 #### Restoring bash history (experimental)
 


### PR DESCRIPTION
`@resurrect-dir` setting is not work with `~`, and it works by removing quates.