### PR TITLE
Save and restore tmux pane contents

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -51,6 +51,11 @@ remove_first_char() {
 	echo "$1" | cut -c2-
 }
 
+capture_pane_contents_option_on() {
+	local option="$(get_tmux_option "$pane_contents_option" "off")"
+	[ "$option" == "on" ]
+}
+
 save_bash_history_option_on() {
 	local option="$(get_tmux_option "$bash_history_option" "off")"
 	[ "$option" == "on" ]
@@ -79,6 +84,11 @@ resurrect_file_path() {
 
 last_resurrect_file() {
 	echo "$(resurrect_dir)/last"
+}
+
+resurrect_pane_file() {
+	local pane_id="$1"
+	echo "$(resurrect_dir)/pane_contents-${pane_id}"
 }
 
 resurrect_history_file() {

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -111,8 +111,8 @@ pane_full_command() {
 
 capture_pane_contents() {
 	local pane_id="$1"
-	local start_line="0"
-	[[ "$(get_tmux_option "$pane_contents_area_option" "visible")" == "full" ]] && start_line="-$2"
+	local start_line="-$2"
+	[[ "$(get_tmux_option "$pane_contents_area_option" "full")" == "visible" ]] && start_line="0"
 	tmux capture-pane -epJ -S "$start_line" -t "$pane_id" > "$(resurrect_pane_file "$pane_id")"
 }
 

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -113,7 +113,7 @@ capture_pane_contents() {
 	local pane_id="$1"
 	local start_line="0"
 	[[ "$(get_tmux_option "$pane_contents_area_option" "visible")" == "full" ]] && start_line="-$2"
-	tmux capture-pane -ep -S "$start_line" -t "$pane_id" > "$(resurrect_pane_file "$pane_id")"
+	tmux capture-pane -epJ -S "$start_line" -t "$pane_id" > "$(resurrect_pane_file "$pane_id")"
 }
 
 save_shell_history() {

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -29,7 +29,13 @@ inline_strategy_token="->"
 save_command_strategy_option="@resurrect-save-command-strategy"
 default_save_command_strategy="ps"
 
+# Pane contents capture options.
+# @resurrect-pane-contents-area option can be:
+#   'visible' - capture only the visible pane area (default)
+#   'full'    - capture the full pane contents
 pane_contents_option="@resurrect-capture-pane-contents"
+pane_contents_area_option="@resurrect-pane-contents-area"
+
 bash_history_option="@resurrect-save-bash-history"
 
 # set to 'on' to ensure panes are never ever overwritten

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -29,6 +29,7 @@ inline_strategy_token="->"
 save_command_strategy_option="@resurrect-save-command-strategy"
 default_save_command_strategy="ps"
 
+pane_contents_option="@resurrect-capture-pane-contents"
 bash_history_option="@resurrect-save-bash-history"
 
 # set to 'on' to ensure panes are never ever overwritten


### PR DESCRIPTION
This PR adds an option to save the pane contents using tmux's `capture-pane`
command, and restore it upon resurrect using good ol' `cat` (as tmux doesn't
seem to provide a command to set the pane contents).

Having tried this at home, it sure feels a lot more like I never quit tmux
after a reboot rather than with all my panes devoid of any output.

This resembles PR #62 but is apparently a lot less complex (not sure why).

Please comment!