### PR TITLE
restore pane contents directly to TTY, not via cat

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -216,7 +216,7 @@ restore_pane_contents() {
 			if ! is_pane_registered_as_existing "$session_name" "$window_number" "$pane_index"; then
 				local pane_id="$session_name:$window_number.$pane_index"
 				local pane_tty=$(tmux display-message -p -F "#{pane_tty}" -t "$pane_id")
-				cat -s "$(resurrect_pane_file "$pane_id")" | perl -pe "chomp if eof" > "$pane_tty"
+				cat -s "$(resurrect_pane_file "$pane_id")" > "$pane_tty"
 			fi
 		done
 }

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -215,8 +215,8 @@ restore_pane_contents() {
 		while IFS=$d read session_name window_number pane_index pane_command; do
 			if ! is_pane_registered_as_existing "$session_name" "$window_number" "$pane_index"; then
 				local pane_id="$session_name:$window_number.$pane_index"
-				local read_command=" cat '$(resurrect_pane_file "$pane_id")'"
-				tmux send-keys -t "$pane_id" "$read_command" C-m
+				local pane_tty=$(tmux display-message -p -F "#{pane_tty}" -t "$pane_id")
+				cat -s "$(resurrect_pane_file "$pane_id")" | perl -pe "chomp if eof" > "$pane_tty"
 			fi
 		done
 }


### PR DESCRIPTION
This commit restores pane contents directly to the pane TTY instead of
executing a "cat" command inside that pane's attached shell session.
Therefore no extraneous "cat" commands are added to your shell history.

It also folds blank lines and omits the final newline during restoration.

https://github.com/tmux-plugins/tmux-resurrect/pull/79#issuecomment-82956797

https://github.com/tmux-plugins/tmux-resurrect/issues/81