### PR TITLE
try to treat inline strategy as alias for strategy

### DIFF
--- a/scripts/process_restore_helpers.sh
+++ b/scripts/process_restore_helpers.sh
@@ -19,6 +19,10 @@ restore_pane_process() {
 
 		local inline_strategy="$(_get_inline_strategy "$pane_full_command")" # might not be defined
 		if [ -n "$inline_strategy" ]; then
+			if _strategy_exists "$inline_strategy"; then
+				local strategy_file="$(_get_strategy_file "$inline_strategy")"
+				local inline_strategy="$($strategy_file "$pane_full_command" "$dir")"
+			fi
 			# inline strategy exists
 			tmux send-keys "$inline_strategy" "C-m"
 		elif _strategy_exists "$pane_full_command"; then


### PR DESCRIPTION
if strategy with that name exists apply it otherwise use it as inline
strategy. This makes vim restore strategy usable with MacVim. 

    set -g @resurrect-strategy-vim 'session'
    set -g @resurrect-processes 'vim man less tail "~Vim->vim"'