### PR TITLE
keep the window names dynamic after restore

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -128,8 +128,3 @@ resurrect_history_file() {
 	local pane_id="$1"
 	echo "$(resurrect_dir)/bash_history-${pane_id}"
 }
-
-join_str() {
-    local str=$(printf "${d}%s" "$@")
-    echo "${str:1}"
-}

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -128,3 +128,8 @@ resurrect_history_file() {
 	local pane_id="$1"
 	echo "$(resurrect_dir)/bash_history-${pane_id}"
 }
+
+join_str() {
+    local str=$(printf "${d}%s" "$@")
+    echo "${str:1}"
+}

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -2,6 +2,8 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+declare -i DYNAMIC_FLAG=2
+
 source "$CURRENT_DIR/variables.sh"
 source "$CURRENT_DIR/helpers.sh"
 source "$CURRENT_DIR/process_restore_helpers.sh"
@@ -117,12 +119,25 @@ new_window() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
+	local rename_option="$6"
 	local pane_id="${session_name}:${window_number}.${pane_index}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
 		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
-		tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir" "$pane_creation_command"
+
+		if [[ $rename_option -ne 0 ]]; then
+			# is dynamic
+			tmux new-window -d -t "${session_name}:${window_number}" -c "$dir" "$pane_creation_command"
+		else
+			tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir" "$pane_creation_command"
+		fi
+
 	else
-		tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir"
+		if [[ $rename_option -ne 0 ]]; then
+			# is dynamic
+			tmux new-window -d -t "${session_name}:${window_number}" -c "$dir"
+		else
+			tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir"
+		fi
 	fi
 }
 
@@ -132,12 +147,27 @@ new_session() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
+	local rename_option="$6"
 	local pane_id="${session_name}:${window_number}.${pane_index}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
 		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
-		TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir" "$pane_creation_command"
+
+		if [[ $rename_option -ne 0 ]]; then
+			# is dynamic
+			TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -c "$dir" "$pane_creation_command"
+		else
+			TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir" "$pane_creation_command"
+		fi
+
 	else
-		TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir"
+
+		if [[ $rename_option -ne 0 ]]; then
+			# is dynamic
+			TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -c "$dir"
+		else
+			TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir"
+		fi
+
 	fi
 	# change first window number if necessary
 	local created_window_num="$(first_window_num)"
@@ -152,7 +182,12 @@ new_pane() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
+	local rename_option="$6"
 	local pane_id="${session_name}:${window_number}.${pane_index}"
+
+	# The following line may be executed repeatedly when creating multiple panes.
+	[[ $rename_option -eq 0 ]] && tmux rename-window -t "$session_name:$window_number" "$window_name"
+
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
 		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
 		tmux split-window -t "${session_name}:${window_number}" -c "$dir" "$pane_creation_command"
@@ -166,6 +201,9 @@ new_pane() {
 restore_pane() {
 	local pane="$1"
 	while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
+
+		declare -i rename_option=$(($window_active & $DYNAMIC_FLAG))
+
 		dir="$(remove_first_char "$dir")"
 		window_name="$(remove_first_char "$window_name")"
 		pane_full_command="$(remove_first_char "$pane_full_command")"
@@ -182,11 +220,11 @@ restore_pane() {
 				register_existing_pane "$session_name" "$window_number" "$pane_index"
 			fi
 		elif window_exists "$session_name" "$window_number"; then
-			new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
+			new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index" "$rename_option"
 		elif session_exists "$session_name"; then
-			new_window "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
+			new_window "$session_name" "$window_number" "$window_name" "$dir" "$pane_index" "$rename_option"
 		else
-			new_session "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
+			new_session "$session_name" "$window_number" "$window_name" "$dir" "$pane_index" "$rename_option"
 		fi
 	done < <(echo "$pane")
 }

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -23,8 +23,7 @@ RESTORE_PANE_CONTENTS="false"
 is_line_type() {
 	local line_type="$1"
 	local line="$2"
-	echo "$line" |
-		\grep -q "^$line_type"
+	grep -q "^$line_type" <<< "$line"
 }
 
 check_saved_session_exists() {
@@ -39,8 +38,8 @@ pane_exists() {
 	local session_name="$1"
 	local window_number="$2"
 	local pane_index="$3"
-	tmux list-panes -t "${session_name}:${window_number}" -F "#{pane_index}" 2>/dev/null |
-		\grep -q "^$pane_index$"
+	tmux list-panes -t "${session_name}:${window_number}" -F "#{pane_index}" 2>/dev/null | \
+		grep -q "^$pane_index$"
 }
 
 register_existing_pane() {
@@ -79,8 +78,8 @@ is_restoring_pane_contents() {
 window_exists() {
 	local session_name="$1"
 	local window_number="$2"
-	tmux list-windows -t "$session_name" -F "#{window_index}" 2>/dev/null |
-		\grep -q "^$window_number$"
+	tmux list-windows -t "$session_name" -F "#{window_index}" 2>/dev/null | \
+		grep -q "^$window_number$"
 }
 
 session_exists() {
@@ -117,13 +116,23 @@ new_window() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
+    local rename_option="$6"
 	local pane_id="${session_name}:${window_number}.${pane_index}"
-	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
-		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
-		tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir" "$pane_creation_command"
-	else
-		tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir"
-	fi
+
+    if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
+        local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
+        if [[ $rename_option == off ]]; then
+            tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir" "$pane_creation_command"
+        else
+            tmux new-window -d -t "${session_name}:${window_number}" -c "$dir" "$pane_creation_command"
+        fi
+    else
+        if [[ $rename_option == off ]]; then
+            tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir"
+        else
+            tmux new-window -d -t "${session_name}:${window_number}" -c "$dir"
+        fi
+    fi
 }
 
 new_session() {
@@ -132,13 +141,24 @@ new_session() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
-	local pane_id="${session_name}:${window_number}.${pane_index}"
-	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
-		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
-		TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir" "$pane_creation_command"
-	else
-		TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir"
-	fi
+    local rename_option="$6"
+    local pane_id="${session_name}:${window_number}.${pane_index}"
+
+    if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
+        local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
+        if [[ $rename_option == off ]]; then
+            TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir" "$pane_creation_command"
+        else
+            TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -c "$dir" "$pane_creation_command"
+        fi
+    else
+        if [[ $rename_option == off ]]; then
+            TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir"
+        else
+            TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -c "$dir"
+        fi
+    fi
+
 	# change first window number if necessary
 	local created_window_num="$(first_window_num)"
 	if [ $created_window_num -ne $window_number ]; then
@@ -153,6 +173,7 @@ new_pane() {
 	local dir="$4"
 	local pane_index="$5"
 	local pane_id="${session_name}:${window_number}.${pane_index}"
+
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
 		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
 		tmux split-window -t "${session_name}:${window_number}" -c "$dir" "$pane_creation_command"
@@ -165,7 +186,8 @@ new_pane() {
 
 restore_pane() {
 	local pane="$1"
-	while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
+	while IFS=$d read line_type session_name window_number window_name rename_option window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
+
 		dir="$(remove_first_char "$dir")"
 		window_name="$(remove_first_char "$window_name")"
 		pane_full_command="$(remove_first_char "$pane_full_command")"
@@ -184,9 +206,9 @@ restore_pane() {
 		elif window_exists "$session_name" "$window_number"; then
 			new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
 		elif session_exists "$session_name"; then
-			new_window "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
+			new_window "$session_name" "$window_number" "$window_name" "$dir" "$pane_index" "$rename_option"
 		else
-			new_session "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
+			new_session "$session_name" "$window_number" "$window_name" "$dir" "$pane_index" "$rename_option"
 		fi
 	done < <(echo "$pane")
 }
@@ -264,14 +286,14 @@ restore_all_panes() {
 }
 
 restore_pane_layout_for_each_window() {
-	\grep '^window' $(last_resurrect_file) |
+	grep '^window' $(last_resurrect_file) |
 		while IFS=$d read line_type session_name window_number window_active window_flags window_layout; do
 			tmux select-layout -t "${session_name}:${window_number}" "$window_layout"
 		done
 }
 
 restore_shell_history() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ { print $2, $3, $7, $10; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ { print $2, $3, $8, $11; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number pane_index pane_command; do
 			if ! is_pane_registered_as_existing "$session_name" "$window_number" "$pane_index"; then
 				if [ "$pane_command" = "bash" ]; then
@@ -288,17 +310,18 @@ restore_shell_history() {
 restore_all_pane_processes() {
 	if restore_pane_processes_enabled; then
 		local pane_full_command
-		awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $11 !~ "^:$" { print $2, $3, $7, $8, $11; }' $(last_resurrect_file) |
+		awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $12 !~ "^:$" { print $2, $3, $8, $9, $12; }' $(last_resurrect_file) |
 			while IFS=$d read session_name window_number pane_index dir pane_full_command; do
 				dir="$(remove_first_char "$dir")"
 				pane_full_command="$(remove_first_char "$pane_full_command")"
+                echo $session_name $window_number $pane_index $dir $pane_full_command >> /tmp/p.txt
 				restore_pane_process "$pane_full_command" "$session_name" "$window_number" "$pane_index" "$dir"
 			done
 	fi
 }
 
 restore_active_pane_for_each_window() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $9 == 1 { print $2, $3, $7; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $10 == 1 { print $2, $3, $8; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number active_pane; do
 			tmux switch-client -t "${session_name}:${window_number}"
 			tmux select-pane -t "$active_pane"
@@ -306,7 +329,7 @@ restore_active_pane_for_each_window() {
 }
 
 restore_zoomed_windows() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $6 ~ /Z/ && $9 == 1 { print $2, $3; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $7 ~ /Z/ && $10 == 1 { print $2, $3; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number; do
 			tmux resize-pane -t "${session_name}:${window_number}" -Z
 		done
@@ -357,3 +380,5 @@ main() {
 	fi
 }
 main
+
+# vim: smarttab:expandtab:ts=4:sw=4:sts=4

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -212,7 +212,7 @@ restore_pane() {
 				# overwrite the pane
 				# happens only for the first pane if it's the only registered pane for the whole tmux server
 				local pane_id="$(tmux display-message -p -F "#{pane_id}" -t "$session_name:$window_number")"
-				new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
+				new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index" "$rename_option"
 				tmux kill-pane -t "$pane_id"
 			else
 				# Pane exists, no need to create it!

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -14,34 +14,73 @@ delimiter=$'\t'
 SCRIPT_OUTPUT="$1"
 
 grouped_sessions_format() {
-    join_str "#{session_grouped}" "#{session_group}" "#{session_id}" "#{session_name}"
+	local format
+	format+="#{session_grouped}"
+	format+="${delimiter}"
+	format+="#{session_group}"
+	format+="${delimiter}"
+	format+="#{session_id}"
+	format+="${delimiter}"
+	format+="#{session_name}"
+	echo "$format"
 }
 
 pane_format() {
-    join_str 'pane' '#{session_name}' '#{window_index}' ':#{window_name}' '#{window_active}' ':#{window_flags}' '#{pane_index}' ':#{pane_current_path}' '#{pane_active}' '#{pane_current_command}' '#{pane_pid}' '#{history_size}'
+	local format
+	format+="pane"
+	format+="${delimiter}"
+	format+="#{session_name}"
+	format+="${delimiter}"
+	format+="#{window_index}"
+	format+="${delimiter}"
+	format+=":#{window_name}"
+	format+="${delimiter}"
+	format+="#{window_active}"
+	format+="${delimiter}"
+	format+=":#{window_flags}"
+	format+="${delimiter}"
+	format+="#{pane_index}"
+	format+="${delimiter}"
+	format+=":#{pane_current_path}"
+	format+="${delimiter}"
+	format+="#{pane_active}"
+	format+="${delimiter}"
+	format+="#{pane_current_command}"
+	format+="${delimiter}"
+	format+="#{pane_pid}"
+	format+="${delimiter}"
+	format+="#{history_size}"
+	echo "$format"
 }
 
 window_format() {
-    join_str 'window' '#{session_name}' '#{window_index}' '#{window_active}' ':#{window_flags}' '#{window_layout}'
+	local format
+	format+="window"
+	format+="${delimiter}"
+	format+="#{session_name}"
+	format+="${delimiter}"
+	format+="#{window_index}"
+	format+="${delimiter}"
+	format+="#{window_active}"
+	format+="${delimiter}"
+	format+=":#{window_flags}"
+	format+="${delimiter}"
+	format+="#{window_layout}"
+	echo "$format"
 }
 
 state_format() {
-    join_str 'state' '#{client_session}' '#{client_last_session}'
+	local format
+	format+="state"
+	format+="${delimiter}"
+	format+="#{client_session}"
+	format+="${delimiter}"
+	format+="#{client_last_session}"
+	echo "$format"
 }
 
 dump_panes_raw() {
-    local _t  # _t is useless
-    local g_rename_option
-    local win_rename_option
-
-    # get the value of global automatic-rename option
-    read _t g_rename_option < <(tmux showw -g automatic-rename)
-
-	tmux list-panes -a -F "$(pane_format)" | \
-		while IFS=$d read line_type session_name window_index window_name window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
-            read _t win_rename_option < <(tmux showw -t "$session_name":"$window_index" automatic-rename)
-            join_str "$line_type" "$session_name" "$window_index" "$window_name" "${win_rename_option:-$g_rename_option}" "$window_active" "$window_flags" "$pane_index" "$dir" "$pane_active" "$pane_command" "$pane_pid" "$history_size"
-        done
+	tmux list-panes -a -F "$(pane_format)"
 }
 
 dump_windows_raw(){
@@ -143,12 +182,9 @@ dump_grouped_sessions() {
 				current_session_group="$session_group"
 			else
 				# this session "points" to the original session
-				#active_window_index="$(get_active_window_index "$session_name")"
-				#alternate_window_index="$(get_alternate_window_index "$session_name")"
-				#echo "grouped_session${d}${session_name}${d}${original_session}${d}:${alternate_window_index}${d}:${active_window_index}"
-				active_window_index=":$(get_active_window_index "$session_name")"
-				alternate_window_index=":$(get_alternate_window_index "$session_name")"
-                join_str "grouped_session" "${session_name}" "${original_session}" "${alternate_window_index}" "${active_window_index}"
+				active_window_index="$(get_active_window_index "$session_name")"
+				alternate_window_index="$(get_alternate_window_index "$session_name")"
+				echo "grouped_session${d}${session_name}${d}${original_session}${d}:${alternate_window_index}${d}:${active_window_index}"
 			fi
 		done
 }
@@ -165,13 +201,13 @@ fetch_and_dump_grouped_sessions(){
 dump_panes() {
 	local full_command
 	dump_panes_raw |
-		while IFS=$d read line_type session_name window_number window_name rename_option window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
+		while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
 			# not saving panes from grouped sessions
 			if is_session_grouped "$session_name"; then
 				continue
 			fi
-			full_command=":$(pane_full_command $pane_pid)"
-            join_str "$line_type" "$session_name" "$window_number" "$window_name" "$rename_option" "$window_active" "$window_flags" "$pane_index" "$dir" "$pane_active" "$pane_command" "$full_command"
+			full_command="$(pane_full_command $pane_pid)"
+			echo "${line_type}${d}${session_name}${d}${window_number}${d}${window_name}${d}${window_active}${d}${window_flags}${d}${pane_index}${d}${dir}${d}${pane_active}${d}${pane_command}${d}:${full_command}"
 		done
 }
 
@@ -191,8 +227,7 @@ dump_windows() {
 				# maximize window again
 				toggle_window_zoom "${session_name}:${window_index}"
 			fi
-			#echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}"
-            join_str "${line_type}" "${session_name}" "${window_index}" "${window_active}" "${window_flags}" "${window_layout}"
+			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}"
 		done
 }
 
@@ -203,14 +238,14 @@ dump_state() {
 dump_pane_contents() {
 	local pane_contents_area="$(get_tmux_option "$pane_contents_area_option" "$default_pane_contents_area")"
 	dump_panes_raw |
-		while IFS=$d read line_type session_name window_number window_name rename_option window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
+		while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
 			capture_pane_contents "${session_name}:${window_number}.${pane_index}" "$history_size" "$pane_contents_area"
 		done
 }
 
 dump_bash_history() {
 	dump_panes |
-		while IFS=$d read line_type session_name window_number window_name rename_option window_active window_flags pane_index dir pane_active pane_command full_command; do
+		while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command full_command; do
 			save_shell_history "$session_name:$window_number.$pane_index" "$pane_command" "$full_command"
 		done
 }
@@ -251,5 +286,3 @@ main() {
 	fi
 }
 main
-
-# vim: smarttab:expandtab:ts=4:sw=4:sts=4


### PR DESCRIPTION
I append an option named `rename_option` after `window_name` to store the value of `automatic-rename` for each pane.
