### PR TITLE
fix soft link error in mac and set pane automatic-rename after restore

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -98,7 +98,7 @@ resurrect_dir() {
 }
 
 resurrect_file_path() {
-	local timestamp="$(date +"%Y-%m-%dT%H:%M:%S")"
+	local timestamp="$(date +"%Y-%m-%dT%H_%M_%S")"
 	echo "$(resurrect_dir)/tmux_resurrect_${timestamp}.txt"
 }
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -188,6 +188,7 @@ restore_pane() {
 		else
 			new_session "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
 		fi
+		tmux set-option -g automatic-rename
 	done < <(echo "$pane")
 }
 


### PR DESCRIPTION
1. Save a session in osx, after restarting, the `last` symbol file will link to incorrect file whose name end with `%Y-%m-%dT%H_%M_%S`.
1. Set pane `automatic-rename` after restoring.