### PR TITLE
auto remove old backup files

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -252,6 +252,13 @@ dump_bash_history() {
 		done
 }
 
+remove_old_backups() {
+	# remove backup files older than 30 days, but keep at least 5 copies of backup.
+	local -a files
+	files=($(ls -t $(resurrect_dir)/*.txt | tail -n +6))
+	[[ ${#files[@]} -eq 0 ]] || find "${files[@]}" -type f -mtime +30 -delete
+}
+
 save_all() {
 	local resurrect_file_path="$(resurrect_file_path)"
 	local last_resurrect_file="$(last_resurrect_file)"
@@ -274,6 +281,7 @@ save_all() {
 	if save_bash_history_option_on; then
 		dump_bash_history
 	fi
+	remove_old_backups
 }
 
 show_output() {


### PR DESCRIPTION
remove backup files older than 30 days, but keep at least 5 copies of backup.

Fixes #102.
