### PR TITLE
Fallback for getting the pane_current_path

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -41,7 +41,7 @@ pane_format() {
 	format+="${delimiter}"
 	format+="#{pane_index}"
 	format+="${delimiter}"
-	format+=":#{pane_current_path}"
+	format+=":#{?pane_current_path,#{pane_current_path},#(lsof -t #{pane_tty} | head -1 | xargs -I % readlink -e /proc/%/cwd)}"
 	format+="${delimiter}"
 	format+="#{pane_active}"
 	format+="${delimiter}"


### PR DESCRIPTION
This might fix #131 and maybe other people's issues where pane_current_path is sometimes not set correctly (happens with Tmux 2.0 on CentOS).

I realize this looks horrendous, but I couldn't find a better solution right now.