### PR TITLE
Send keys to the correct pane

### DIFF
--- a/scripts/process_restore_helpers.sh
+++ b/scripts/process_restore_helpers.sh
@@ -17,6 +17,7 @@ restore_pane_process() {
 		tmux switch-client -t "${session_name}:${window_number}"
 		tmux select-pane -t "$pane_index"
 
+		local pane_id="$session_name:$window_number.$pane_index"
 		local inline_strategy="$(_get_inline_strategy "$pane_full_command")" # might not be defined
 		if [ -n "$inline_strategy" ]; then
 			# inline strategy exists
@@ -25,14 +26,14 @@ restore_pane_process() {
 				local strategy_file="$(_get_strategy_file "$inline_strategy")"
 				local inline_strategy="$($strategy_file "$pane_full_command" "$dir")"
 			fi
-			tmux send-keys "$inline_strategy" "C-m"
+			tmux send-keys -t "$pane_id" "$inline_strategy" "C-m"
 		elif _strategy_exists "$pane_full_command"; then
 			local strategy_file="$(_get_strategy_file "$pane_full_command")"
 			local strategy_command="$($strategy_file "$pane_full_command" "$dir")"
-			tmux send-keys "$strategy_command" "C-m"
+			tmux send-keys -t "$pane_id" "$strategy_command" "C-m"
 		else
 			# just invoke the command
-			tmux send-keys "$pane_full_command" "C-m"
+			tmux send-keys -t "$pane_id" "$pane_full_command" "C-m"
 		fi
 	fi
 }


### PR DESCRIPTION
The process restoring feature of tmux-resurrect did not work at all for me because all the keys got sent to the same pane. I have fixed the `send-keys` commands in `process_restore_helpers.sh` to include the target pane ID, as is already done in `restore.sh`.