### PR TITLE
remove terminal clearing since it collides with capture-pane-contents

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -276,9 +276,7 @@ restore_shell_history() {
 			if ! is_pane_registered_as_existing "$session_name" "$window_number" "$pane_index"; then
 				if [ "$pane_command" == "bash" ]; then
 					local pane_id="$session_name:$window_number.$pane_index"
-					# tmux send-keys has -R option that should reset the terminal.
-					# However, appending 'clear' to the command seems to work more reliably.
-					local read_command="history -r '$(resurrect_history_file "$pane_id")'; clear"
+					local read_command="history -r '$(resurrect_history_file "$pane_id")'"
 					tmux send-keys -t "$pane_id" "$read_command" C-m
 				fi
 			fi


### PR DESCRIPTION
The clearing of the terminal after history restore is not a feature. 
It conflicts with `resurrect-capture-pane-contents`. 
If you have both history restoration and content capture turned on, the screen will be restored then promptly erased.