### PR TITLE
add hostname to the path for saving and restoring sessions

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,4 +1,4 @@
-default_resurrect_dir="$HOME/.tmux/resurrect"
+default_resurrect_dir="$HOME/.tmux/resurrect/$(hostname)"
 resurrect_dir_option="@resurrect-dir"
 
 SUPPORTED_VERSION="1.9"


### PR DESCRIPTION
This change is used for supporting saving and restoring sessions for the NFS on different servers.