### PR TITLE
Changed the resurrect file path to allow it to work with Microsoft WLS

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -112,7 +112,7 @@ _RESURRECT_DIR="$(resurrect_dir)"
 
 resurrect_file_path() {
 	if [ -z "$_RESURRECT_FILE_PATH" ]; then
-		local timestamp="$(date +"%Y-%m-%dT%H:%M:%S")"
+		local timestamp="$(date +"%Y-%m-%dT%H_%M_%S")"
 		echo "$(resurrect_dir)/${RESURRECT_FILE_PREFIX}_${timestamp}.${RESURRECT_FILE_EXTENSION}"
 	else
 		echo "$_RESURRECT_FILE_PATH"


### PR DESCRIPTION
The Microsoft Windows Linux Subsystem does not accept ":" on the file path. I did a small modification so the resurrect could work with Microsoft WLS. The side effect of this change is that is a user already have a resurrect file saved, it would have to save it again.