### PR TITLE
remove_old_backups() : replace xargs with -exec to handle 0 files found better

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -283,7 +283,7 @@ remove_old_backups() {
 	local -a files
 	files=($(ls -t $(resurrect_dir)/${RESURRECT_FILE_PREFIX}_*.${RESURRECT_FILE_EXTENSION} | tail -n +6))
 	[[ ${#files[@]} -eq 0 ]] ||
-		find "${files[@]}" -type f -mtime +30 | xargs rm
+		find "${files[@]}" -type f -mtime +30 -exec rm -v "{}" \;
 }
 
 save_all() {


### PR DESCRIPTION
If there are no files found by find due to mtime (ie, nothing older than 30 days), zero arguments are passed on to xargs' rm which result in 

Oct 25 14:14:50 xmachina save.sh[2772]: rm: missing operand
Oct 25 14:14:50 xmachina save.sh[2772]: Try 'rm --help' for more information.

to be seen in journalctl.

This way rm is only executed when something is found.