### PR TITLE
Fixed auto-renaming of windows (#57)

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -270,6 +270,13 @@ restore_pane_layout_for_each_window() {
 		done
 }
 
+restore_rename_option_for_each_window() {
+	awk 'BEGIN { FS="\t"; OFS="\t" } /^window/ { print $2, $3, $7; }' $(last_resurrect_file) |
+		while IFS=$d read session_name window_number window_auto_rename_option; do
+			tmux set-window-option -t "${session_name}:${window_number}" automatic-rename "$window_auto_rename_option"
+		done
+}
+
 restore_shell_history() {
 	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ { print $2, $3, $7, $10; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number pane_index pane_command; do
@@ -356,6 +363,7 @@ main() {
 		restore_grouped_sessions  # also restores active and alt windows for grouped sessions
 		restore_active_and_alternate_windows
 		restore_active_and_alternate_sessions
+		restore_rename_option_for_each_window
 		stop_spinner
 		display_message "Tmux restore complete!"
 	fi

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -244,6 +244,13 @@ dump_windows() {
 			if is_session_grouped "$session_name"; then
 				continue
 			fi
+			# get window automatic renaming configuration
+			window_auto_rename_option="$(tmux show-window-option -t "${session_name}:${window_index}" automatic-rename)"
+			if [[ -z "$window_auto_rename_option" ]]; then
+				window_auto_rename_option="on"
+			else
+				window_auto_rename_option="off"
+			fi
 			# window_layout is not correct for zoomed windows
 			if [[ "$window_flags" == *Z* ]]; then
 				# unmaximize the window
@@ -255,7 +262,7 @@ dump_windows() {
 				# maximize window again
 				toggle_window_zoom "${session_name}:${window_index}"
 			fi
-			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}"
+			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}${d}${window_auto_rename_option}"
 		done
 }
 


### PR DESCRIPTION
The automatic-renaming option of each window is saved in session files and restored accordingly.