### PR TITLE
Save and restore hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You should now be able to use the plugin.
 **Configuration**
 
 - [Changing the default key bindings](docs/custom_key_bindings.md).
+- [Setting up hooks on save & restore](docs/hooks.md).
 - Only a conservative list of programs is restored by default:<br/>
   `vi vim nvim emacs man less more tail top htop irssi weechat mutt`.<br/>
   [Restoring programs doc](docs/restoring_programs.md) explains how to restore

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,14 @@
+# Save & Restore Hooks
+
+Hooks allow to set custom commands that will be executed during session save and restore.
+
+Currently the following hooks are supported:
+
+- `@resurrect-save-hook` - executed after session save
+- `@resurrect-restore-hook` - executed before session restore
+
+Here is an example how to save and restore window geometry for most terminals in X11.
+Add this to `.tmux.conf`:
+
+    set -g @resurrect-save-hook 'eval $(xdotool getwindowgeometry --shell $WINDOWID); echo 0,$X,$Y,$WIDTH,$HEIGHT > $HOME/.tmux/resurrect/geometry'
+    set -g @resurrect-restore-hook 'wmctrl -i -r $WINDOWID -e $(cat $HOME/.tmux/resurrect/geometry)'

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -148,3 +148,14 @@ resurrect_history_file() {
 	local shell_name="$2"
 	echo "$(resurrect_dir)/${shell_name}_history-${pane_id}"
 }
+
+# hook helpers
+
+save_hook() {
+	get_tmux_option "$save_hook_option" "$save_hook_default"
+}
+
+restore_hook() {
+	get_tmux_option "$restore_hook_option" "$restore_hook_default"
+}
+

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -344,6 +344,9 @@ restore_active_and_alternate_sessions() {
 main() {
 	if supported_tmux_version_ok && check_saved_session_exists; then
 		start_spinner "Restoring..." "Tmux restore complete!"
+		if [ -n "$(restore_hook)" ]; then
+			eval "$(restore_hook)"
+		fi
 		restore_all_panes
 		restore_pane_layout_for_each_window >/dev/null 2>&1
 		if save_shell_history_option_on; then

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -325,6 +325,9 @@ main() {
 			stop_spinner
 			display_message "Tmux environment saved!"
 		fi
+		if [ -n "$(save_hook)" ]; then
+			eval "$(save_hook)"
+		fi
 	fi
 }
 main

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -42,3 +42,9 @@ shell_history_option="@resurrect-save-shell-history"
 
 # set to 'on' to ensure panes are never ever overwritten
 overwrite_option="@resurrect-never-overwrite"
+
+# Hooks
+restore_hook_default=""
+restore_hook_option="@resurrect-restore-hook"
+save_hook_default=""
+save_hook_option="@resurrect-save-hook"


### PR DESCRIPTION
Adds two for save restore events, that could be used to e.g. save and restore terminal window geometry, like so:

```
set -g @resurrect-save-hook 'eval $(xdotool getwindowgeometry --shell $WINDOWID); echo 0,$X,$Y,$WIDTH,$HEIGHT > $HOME/.tmux/resurrect/geometry'
set -g @resurrect-restore-hook 'wmctrl -i -r $WINDOWID -e $(cat $HOME/.tmux/resurrect/geometry)'
```