### PR TITLE
Fix https://github.com/tmux-plugins/tmux-resurrect/issues/176.

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -246,14 +246,8 @@ dump_windows() {
 			fi
 			# window_layout is not correct for zoomed windows
 			if [[ "$window_flags" == *Z* ]]; then
-				# unmaximize the window
-				toggle_window_zoom "${session_name}:${window_index}"
 				# get correct window layout
 				window_layout="$(tmux display-message -p -t "${session_name}:${window_index}" -F "#{window_layout}")"
-				# sleep required otherwise vim does not redraw correctly, issue #112
-				sleep 0.1 || sleep 1 # portability hack
-				# maximize window again
-				toggle_window_zoom "${session_name}:${window_index}"
 			fi
 			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}"
 		done

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -244,11 +244,6 @@ dump_windows() {
 			if is_session_grouped "$session_name"; then
 				continue
 			fi
-			# window_layout is not correct for zoomed windows
-			if [[ "$window_flags" == *Z* ]]; then
-				# get correct window layout
-				window_layout="$(tmux display-message -p -t "${session_name}:${window_index}" -F "#{window_layout}")"
-			fi
 			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}"
 		done
 }

--- a/tests/fixtures/restore_file.txt
+++ b/tests/fixtures/restore_file.txt
@@ -4,9 +4,9 @@ pane	blue	1	:man	0	:-	0	:/tmp	0	bash	:
 pane	blue	1	:man	0	:-	1	:/usr/share/man	1	man	:man echo
 pane	blue	2	:bash	1	:*	0	:/tmp	1	bash	:
 pane	red	0	:bash	0	:	0	:/tmp	1	bash	:
-pane	red	1	:bash	0	:-	0	:/tmp	0	bash	:
-pane	red	1	:bash	0	:-	1	:/tmp	0	bash	:
-pane	red	1	:bash	0	:-	2	:/tmp	1	bash	:
+pane	red	1	:bash	0	:-Z	0	:/tmp	0	bash	:
+pane	red	1	:bash	0	:-Z	1	:/tmp	0	bash	:
+pane	red	1	:bash	0	:-Z	2	:/tmp	1	bash	:
 pane	red	2	:bash	1	:*	0	:/tmp	0	bash	:
 pane	red	2	:bash	1	:*	1	:/tmp	1	bash	:
 pane	yellow	0	:bash	1	:*	0	:/tmp/bar	1	bash	:
@@ -15,7 +15,7 @@ window	blue	0	0	:	ce9f,200x49,0,0,2
 window	blue	1	0	:-	178b,200x49,0,0{100x49,0,0,3,99x49,101,0,4}
 window	blue	2	1	:*	cea2,200x49,0,0,5
 window	red	0	0	:	cea3,200x49,0,0,6
-window	red	1	0	:-	135b,200x49,0,0[200x24,0,0,7,200x24,0,25{100x24,0,25,8,99x24,101,25,9}]
+window	red	1	0	:-Z	135b,200x49,0,0[200x24,0,0,7,200x24,0,25{100x24,0,25,8,99x24,101,25,9}]
 window	red	2	1	:*	db81,200x49,0,0[200x24,0,0,10,200x24,0,25,11]
 window	yellow	0	1	:*	6781,200x49,0,0,12
 state	yellow	blue

--- a/tests/fixtures/save_file.txt
+++ b/tests/fixtures/save_file.txt
@@ -4,9 +4,9 @@ pane	blue	1	:man	0	:!-	0	:/tmp	0	bash	:
 pane	blue	1	:man	0	:!-	1	:/usr/share/man	1	man	:man echo
 pane	blue	2	:bash	1	:*	0	:/tmp	1	bash	:
 pane	red	0	:bash	0	:	0	:/tmp	1	bash	:
-pane	red	1	:bash	0	:-	0	:/tmp	0	bash	:
-pane	red	1	:bash	0	:-	1	:/tmp	0	bash	:
-pane	red	1	:bash	0	:-	2	:/tmp	1	bash	:
+pane	red	1	:bash	0	:-Z	0	:/tmp	0	bash	:
+pane	red	1	:bash	0	:-Z	1	:/tmp	0	bash	:
+pane	red	1	:bash	0	:-Z	2	:/tmp	1	bash	:
 pane	red	2	:bash	1	:*	0	:/tmp	0	bash	:
 pane	red	2	:bash	1	:*	1	:/tmp	1	bash	:
 pane	yellow	0	:bash	1	:*	0	:/tmp/bar	1	bash	:
@@ -15,7 +15,7 @@ window	blue	0	0	:!	cea4,200x49,0,0,7
 window	blue	1	0	:!-	9797,200x49,0,0{100x49,0,0,8,99x49,101,0,9}
 window	blue	2	1	:*	677f,200x49,0,0,10
 window	red	0	0	:	ce9e,200x49,0,0,1
-window	red	1	0	:-	52b7,200x49,0,0[200x24,0,0,2,200x24,0,25{100x24,0,25,3,99x24,101,25,4}]
+window	red	1	0	:-Z	52b7,200x49,0,0[200x24,0,0,2,200x24,0,25{100x24,0,25,3,99x24,101,25,4}]
 window	red	2	1	:*	bd68,200x49,0,0[200x24,0,0,5,200x24,0,25,6]
 window	yellow	0	1	:*	6780,200x49,0,0,11
 state	yellow	blue

--- a/tests/helpers/create_and_save_tmux_test_environment.exp
+++ b/tests/helpers/create_and_save_tmux_test_environment.exp
@@ -16,6 +16,7 @@ new_tmux_session "red"
 new_tmux_window
 horizontal_split
 vertical_split
+toggle_zoom_pane
 
 new_tmux_window
 horizontal_split

--- a/tests/helpers/expect_helpers.exp
+++ b/tests/helpers/expect_helpers.exp
@@ -44,6 +44,11 @@ proc vertical_split {} {
   sleep 0.1
 }
 
+proc toggle_zoom_pane {} {
+  send "z"
+  sleep 0.2
+}
+
 proc run_shell_command {command} {
   send "$command\r"
   sleep 1


### PR DESCRIPTION
This removes (un)zooming on save which should not be necessary anymore with recent tmux versions, this should fix #176.
I think the relevant change in tmux itself has been made in [this commit](https://github.com/tmux/tmux/commit/531869bd92f0daff3cc3c3cc0ab273846f411dc8), so this change should work for tmux >=2.2.

Update: I have extended the tests a bit to also save and restore a zoomed pane.