### PR TITLE
#253: Get children process running within bash 

### DIFF
--- a/save_command_strategies/ps.sh
+++ b/save_command_strategies/ps.sh
@@ -22,7 +22,8 @@ full_command() {
 	ps "$(ps_command_flags)" "ppid command" |
 		sed "s/^ *//" |
 		grep "^${PANE_PID}" |
-		cut -d' ' -f2-
+		cut -d' ' -f2- |
+		tail -1
 }
 
 main() {


### PR DESCRIPTION
Okay, after a little research, I understood what's going on and was able to make a workaround for this.

The restore was working fine because in `scripts/process_restore_helpers.sh`, in the `_process_should_be_restored`, we were in the first scenario, as the comment says, `where pane existed before restoration, so we're not restoring the process either`. So this is fine since the processes are not actually restored.

The problem comes when the processes have to be restored, caused by the txt restore files saved in `~/.tmux/restore`. The saved command is always `:-zsh`, saving the running children in a new line:

```
pane	1	1	:zsh	1	:*	0	:/home/jpardo/.tmux/plugins/tmux-resurrect	0	vim	:-zsh
vim -S
pane	1	1	:zsh	1	:*	1	:/home/jpardo/git/tmux-resurrect	1	zsh	:-zsh
pane	1	2	:ssh	0	:	0	:/home/jpardo	0	ssh	:-zsh
ssh h2601438.stratoserver.net
pane	1	2	:ssh	0	:	1	:/home/jpardo/.tmux/plugins/tmux-resurrect	1	zsh	:-zsh
pane	1	3	:zsh	0	:-	0	:/home/jpardo	0	mysql	:-zsh
mysql -uroot -p
pane	1	3	:zsh	0	:-	1	:/home/jpardo/.tmux/resurrect	1	zsh	:-zsh
pane	1	4	:python3	0	:	0	:/home/jpardo	1	python3	:-zsh
python3
pane	1	5	:php	0	:	0	:/home/jpardo	1	php	:-zsh
php -a
pane	main	1	:zsh	1	:*	0	:/home/jpardo	1	zsh	:-zsh
window	1	1	1	:*	850a,211x61,0,0[211x34,0,0,2,211x26,0,35,3]
window	1	2	0	:	9942,211x61,0,0{105x61,0,0,4,105x61,106,0,5}
window	1	3	0	:-	0d95,211x61,0,0[211x28,0,0,6,211x32,0,29,7]
window	1	4	0	:	b365,211x61,0,0,8
window	1	5	0	:	b366,211x61,0,0,9
window	main	1	1	:*	59df,211x61,0,0,10
state	1	main
```

The `vim`, `ssh`, etc. commands are saved in a new line.

I modified the `save_command_strategies/ps.sh` to tail the last line of the `ps` output, so the resulting `last` with this workaround would be:


```
pane	1	1	:zsh	1	:*	0	:/home/jpardo/.tmux/plugins/tmux-resurrect	0	vim	:vim -S
pane	1	1	:zsh	1	:*	1	:/home/jpardo/git/tmux-resurrect	1	zsh	:-zsh
pane	1	2	:ssh	0	:-	0	:/home/jpardo	0	ssh	:ssh h2601438.stratoserver.net
pane	1	2	:ssh	0	:-	1	:/home/jpardo/.tmux/plugins/tmux-resurrect	1	zsh	:-zsh
pane	1	3	:zsh	0	:	0	:/home/jpardo	0	mysql	:mysql -uroot -p
pane	1	3	:zsh	0	:	1	:/home/jpardo/.tmux/resurrect	1	zsh	:-zsh
pane	1	4	:python3	0	:	0	:/home/jpardo	1	python3	:python3
pane	1	5	:php	0	:	0	:/home/jpardo	1	php	:php -a
pane	main	1	:zsh	1	:*	0	:/home/jpardo	1	zsh	:-zsh
window	1	1	1	:*	850a,211x61,0,0[211x34,0,0,2,211x26,0,35,3]
window	1	2	0	:-	9942,211x61,0,0{105x61,0,0,4,105x61,106,0,5}
window	1	3	0	:	0d95,211x61,0,0[211x28,0,0,6,211x32,0,29,7]
window	1	4	0	:	b365,211x61,0,0,8
window	1	5	0	:	b366,211x61,0,0,9
window	main	1	1	:*	59df,211x61,0,0,10
state	1	main
```

Which allows the successful restore of the processes.