### PR TITLE
Make backup retention period configurable

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -269,10 +269,11 @@ dump_shell_history() {
 
 remove_old_backups() {
 	# remove resurrect files older than 30 days, but keep at least 5 copies of backup.
+	local delete_after="$(get_tmux_option "$backup_retention_period_option" "$default_backup_retention_period")"
 	local -a files
 	files=($(ls -t $(resurrect_dir)/${RESURRECT_FILE_PREFIX}_*.${RESURRECT_FILE_EXTENSION} | tail -n +6))
 	[[ ${#files[@]} -eq 0 ]] ||
-		find "${files[@]}" -type f -mtime +30 -exec rm -v "{}" \;
+		find "${files[@]}" -type f -mtime "${delete_after}" -exec rm -v "{}" \;
 }
 
 save_all() {

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -42,3 +42,6 @@ shell_history_option="@resurrect-save-shell-history"
 
 # set to 'on' to ensure panes are never ever overwritten
 overwrite_option="@resurrect-never-overwrite"
+
+backup_retention_period_option="@resurrect-backup-retention-period"
+default_backup_retention_period="+30d"


### PR DESCRIPTION
For instance `tmux set-option -g @resurrect-backup-retention-period +1d` to only keep 1 day of backups.

Closes #252.