### PR TITLE
Fix #94 start default-shell as login shell.

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -100,7 +100,7 @@ tmux_socket() {
 # tmux server each time.
 cache_tmux_default_command() {
 	local default_shell="$(get_tmux_option "default-shell" "")"
-	export TMUX_DEFAULT_COMMAND="$(get_tmux_option "default-command" "$default_shell")"
+	export TMUX_DEFAULT_COMMAND="$(get_tmux_option "default-command" "-l $default_shell")"
 }
 
 tmux_default_command() {


### PR DESCRIPTION
If pane content is restored and no default-command is set, restore.sh
falls back to default-shell, which tmux sets automatically and calls as
a login shell.

In pane_creation_command() we need to make sure to call default-shell as a login shell.
As tmux does. But take care not to call default-command as a login shell.