### PR TITLE
Add mosh-client default strategy

### DIFF
--- a/docs/restoring_programs.md
+++ b/docs/restoring_programs.md
@@ -2,6 +2,7 @@
   - [General instructions](#general-instructions)
   - [Clarifications](#clarifications)
   - [Working with NodeJS](#nodejs)
+  - [Restoring Mosh](#mosh)
 
 ### General instructions <a name="general-instructions"></a>
 Only a conservative list of programs is restored by default:<br/>
@@ -169,3 +170,10 @@ A work around, for this problem until it's fixed, is:
 
       ... node:node /path/to/yarn gulp "test-it"
 
+
+### Restoring Mosh <a name="#mosh"></a>
+Mosh spawns a `mosh-client` process, so we need to specify that as the process to be resurrected.
+
+    set -g @resurrect-processes 'mosh-client'
+
+Additionally a mosh-client strategy is provided to handle extracting the original arguments and re-run Mosh.

--- a/resurrect.tmux
+++ b/resurrect.tmux
@@ -23,6 +23,7 @@ set_restore_bindings() {
 
 set_default_strategies() {
 	tmux set-option -gq "${restore_process_strategy_option}irb" "default_strategy"
+	tmux set-option -gq "${restore_process_strategy_option}mosh-client" "default_strategy"
 }
 
 set_script_path_options() {

--- a/strategies/mosh-client_default_strategy.sh
+++ b/strategies/mosh-client_default_strategy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# "mosh-client default strategy"
+#
+# Example mosh-client process:
+#   mosh-client -# charm tmux at | 198.199.104.142 60001
+#
+# When executed, the above will fail. This strategy handles that.
+
+ORIGINAL_COMMAND="$1"
+DIRECTORY="$2"
+
+mosh_command() {
+	local args="$ORIGINAL_COMMAND"
+
+	args="${args#*-#}"
+	args="${args%|*}"
+
+	echo "mosh $args"
+}
+
+main() {
+	echo "$(mosh_command)"
+}
+main


### PR DESCRIPTION
This also includes changes to `restoring_programs.md` in order to let people
know to use `mosh-client` rather than `mosh`