### PR TITLE
Some fixes for zsh history save/restore

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -166,3 +166,18 @@ execute_hook() {
 		eval "$hook $args"
 	fi
 }
+
+# This is a bit of a hack to handle escape sequences, since TMUX doesn't seem to recognize '^[[4~'
+_tmux_send_keys() {
+	local key
+	local keys=()
+
+	for key in "$@"; do
+		case "${key:0:2}" in
+			"^[") keys+=("[^" "${key:2}");;
+			*) keys+=("$key");;
+		esac
+	done
+
+	tmux send-keys -t "$pane_id" "${keys[@]}"
+}

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -285,7 +285,11 @@ restore_shell_history() {
 				elif [ "$pane_command" = "zsh" ]; then
 					local accept_line="$(expr "$(zsh -i -c bindkey | grep -m1 '\saccept-line$')" : '^"\(.*\)".*')"
 					local read_command="fc -R '$history_file'; clear"
-					tmux send-keys -t "$pane_id" "$read_command" "$accept_line"
+
+					# zsh defaults to bash-compatable bindings if not bound
+					accept_line=${accept_line:-C-m}
+
+					_tmux_send_keys "$read_command" "$accept_line"
 				fi
 			fi
 		done

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -162,6 +162,11 @@ save_shell_history() {
 		local accept_line="$(expr "$(echo "$zsh_bindkey" | grep -m1 '\saccept-line$')" : '^"\(.*\)".*')"
 		local end_of_line="$(expr "$(echo "$zsh_bindkey" | grep -m1 '\send-of-line$')" : '^"\(.*\)".*')"
 		local backward_kill_line="$(expr "$(echo "$zsh_bindkey" | grep -m1 '\sbackward-kill-line$')" : '^"\(.*\)".*')"
+
+		# zsh defaults to bash-compatable bindings if not bound
+		accept_line=${accept_line:-C-m}
+		end_of_line=${end_of_line:-C-e}
+		backward_kill_line=${backward_kill_line:-C-u}
 	else
 		return
 	fi
@@ -176,9 +181,9 @@ save_shell_history() {
 		local read_command=" $history_r '$(resurrect_history_file "$pane_id" "$pane_command")'"
 		# C-e C-u is a Bash shortcut sequence to clear whole line. It is necessary to
 		# delete any pending input so it does not interfere with our history command.
-		tmux send-keys -t "$pane_id" "$end_of_line" "$backward_kill_line" "$write_command" "$accept_line"
+		_tmux_send_keys "$end_of_line" "$backward_kill_line" "$write_command" "$accept_line"
 		# Immediately restore after saving
-		tmux send-keys -t "$pane_id" "$end_of_line" "$backward_kill_line" "$read_command" "$accept_line"
+		_tmux_send_keys "$end_of_line" "$backward_kill_line" "$read_command" "$accept_line"
 	fi
 }
 


### PR DESCRIPTION
I noticed some of the keybindings for zsh either weren't set or had values that
gave TMUX some trouble.  This PR should fix that.