### PR TITLE
Adds a fix for directory paths with spaces that aren't escaped.

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -233,6 +233,7 @@ dump_panes() {
 				continue
 			fi
 			full_command="$(pane_full_command $pane_pid)"
+			dir=$(echo $dir | sed 's/ /\\ /') # escape all spaces in directory path
 			echo "${line_type}${d}${session_name}${d}${window_number}${d}${window_name}${d}${window_active}${d}${window_flags}${d}${pane_index}${d}${dir}${d}${pane_active}${d}${pane_command}${d}:${full_command}"
 		done
 }


### PR DESCRIPTION
When you're working in a path that has a unescaped space character in the path, restoring does not work as intended.

A path like:
`/Users/joseph/Desktop/hello world/deeper`

is saved in the resurrect file as:
`/Users/joseph/Desktop/hello\ world/deeper`

Closes issue #162 