### PR TITLE
Proposal to hide the input commands saving/restoring bash history:

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -281,7 +281,7 @@ restore_shell_history() {
 
 				if [ "$pane_command" = "bash" ]; then
 					local read_command="history -r '$history_file'"
-					tmux send-keys -t "$pane_id" "$read_command" C-m
+					tmux send-keys -t "$pane_id" M-z "$read_command" C-m M-Z
 				elif [ "$pane_command" = "zsh" ]; then
 					local accept_line="$(expr "$(zsh -i -c bindkey | grep -m1 '\saccept-line$')" : '^"\(.*\)".*')"
 					local read_command="fc -R '$history_file'; clear"

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -176,9 +176,8 @@ save_shell_history() {
 		local read_command=" $history_r '$(resurrect_history_file "$pane_id" "$pane_command")'"
 		# C-e C-u is a Bash shortcut sequence to clear whole line. It is necessary to
 		# delete any pending input so it does not interfere with our history command.
-		tmux send-keys -t "$pane_id" "$end_of_line" "$backward_kill_line" "$write_command" "$accept_line"
-		# Immediately restore after saving
-		tmux send-keys -t "$pane_id" "$end_of_line" "$backward_kill_line" "$read_command" "$accept_line"
+		# and immediately restore after saving
+		tmux send-keys -t "$pane_id" "$end_of_line" "$backward_kill_line" M-z "$write_command;$read_command" "$accept_line" M-Z
 	fi
 }
 


### PR DESCRIPTION
I configured my tmux to use resurrect save on each detach, but with the option `resurrect-save-shell-history` ON, this creates a lot of useless "history" lines in my panes. So I created a configuration to hide those commands. It's super experimental, uses unchecked key mappings, so I make this pull request for the reference, but this might need improvement, or another implementation idea.

First, the following must be configured in your ~/.bashrc:
bind -x '"\C-[z": tput smcut'  # Enter a secondary terminal buffer with Alt-z
bind -x '"\C-[Z": tput rmcut'  # Quit it with Alt-Z

Then the tmux sent keys can include those controls around the executed
commands to invisibly save/restore the history.