### PR TITLE
Corrected what is the expected value of the $CURRENT_DIR

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Absolute path to this script, e.g. /home/user/.tmux/plugins/tmux-resurrect/scripts/save.sh
+SCRIPT=$(readlink -f "$0")
+# Absolute path this script is in, thus /home/user/.tmux/plugins/tmux-resurrect/scripts
+SCRIPT_PATH=$(dirname "$SCRIPT")
+echo "SCRIPT_PATH -> $SCRIPT_PATH"
 
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "CURRENT_DIR -> $CURRENT_DIR"
+
+# $CURRENT_DIR seems is expected to be an absolut path this script is located in
+CURRENT_DIR="$SCRIPT_PATH"
 source "$CURRENT_DIR/variables.sh"
 source "$CURRENT_DIR/helpers.sh"
 source "$CURRENT_DIR/process_restore_helpers.sh"

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
+# Absolute path to this script, e.g. /home/user/.tmux/plugins/tmux-resurrect/scripts/save.sh
+SCRIPT=$(readlink -f "$0")
+# Absolute path this script is in, thus /home/user/.tmux/plugins/tmux-resurrect/scripts
+SCRIPT_PATH=$(dirname "$SCRIPT")
+echo "SCRIPT_PATH -> $SCRIPT_PATH"
+
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "CURRENT_DIR -> $CURRENT_DIR"
+
+# $CURRENT_DIR seems is expected to be an absolut path this script is located in
+CURRENT_DIR="$SCRIPT_PATH"
 
 source "$CURRENT_DIR/variables.sh"
 source "$CURRENT_DIR/helpers.sh"


### PR DESCRIPTION
It is necessary for the cases when running the scripts (as symlinks) without a
possibility of using key bindings as advised in issue #179
https://github.com/tmux-plugins/tmux-resurrect/issues/179

The case is e.g. saving the sessions for byobu and having the symlinks
created at $HOME/bin/ as:
byobu-session-restore ->
/home/delphym/.tmux/plugins/tmux-resurrect/scripts/restore.sh

byobu-session-save ->
/home/delphym/.tmux/plugins/tmux-resurrect/scripts/save.sh
