### PR TITLE
Add resurrect-limit-shell-history option

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -6,6 +6,7 @@ RESURRECT_FILE_PREFIX="tmux_resurrect"
 RESURRECT_FILE_EXTENSION="txt"
 _RESURRECT_DIR=""
 _RESURRECT_FILE_PATH=""
+HISTORY_DATE_FILE_PREFIX="shell_history_saved"
 
 d=$'\t'
 
@@ -69,6 +70,11 @@ save_shell_history_option_on() {
 	local option_bash="$(get_tmux_option "$bash_history_option" "off")"
 
 	[ "$option_shell" == "on" ] || [ "$option_bash" == "on" ]
+}
+
+limit_save_shell_history_option_on() {
+	local option="$(get_tmux_option "$limit_shell_history_option" "off")"
+	[ "$option" == "on" ]
 }
 
 get_grouped_sessions() {
@@ -165,4 +171,24 @@ execute_hook() {
 	if [ -n "$hook" ]; then
 		eval "$hook $args"
 	fi
+}
+
+history_date_file() {
+  current_date=$(date +"%Y_%m_%d")
+  echo "$HISTORY_DATE_FILE_PREFIX""_""$current_date"
+}
+
+history_file_current() {
+  if $(limit_save_shell_history_option_on); then
+    ls $(resurrect_dir) | grep $(history_date_file) > /dev/null
+    echo $?
+  else
+    echo "1"
+  fi
+}
+
+update_history_date_file() {
+  rm -f "$(resurrect_dir)/$HISTORY_DATE_FILE_PREFIX""_""*"
+  current_date=$(date +"%Y_%m_%d")
+  touch "$(resurrect_dir)/$HISTORY_DATE_FILE_PREFIX""_""$current_date"
 }

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -262,10 +262,13 @@ dump_pane_contents() {
 }
 
 dump_shell_history() {
-	dump_panes |
-		while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command full_command; do
-			save_shell_history "$session_name:$window_number.$pane_index" "$pane_command" "$full_command"
-		done
+  if [[ "$(history_file_current)" == "1" ]]; then
+    dump_panes |
+      while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command full_command; do
+        save_shell_history "$session_name:$window_number.$pane_index" "$pane_command" "$full_command"
+      done
+    update_history_date_file
+  fi
 }
 
 remove_old_backups() {

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -39,6 +39,7 @@ default_pane_contents_area="full"
 
 bash_history_option="@resurrect-save-bash-history" # deprecated
 shell_history_option="@resurrect-save-shell-history"
+limit_shell_history_option="@resurrect-limit-save-shell-history"
 
 # set to 'on' to ensure panes are never ever overwritten
 overwrite_option="@resurrect-never-overwrite"


### PR DESCRIPTION
This patch adds a new tmux-ressurect option,
resurrect-limit-shell-history, to limit the frequency of saving shell
history to once per day. The motivation of this option is that otherwise
resurrect is run much more frequently (e.g., ~ every 15 minutes), and
saving the history spams the console (saving other state does not...).
Spamming the console ~once per day, while still saving history, seems
like a reasonable tradeoff---hence this patch.