### PR TITLE
Deprecate restoring shell history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - delete resurrect files older than 30 days, but keep at least 5 files
 - add save and restore hooks
 - always use `-ao` flags for `ps` command to detect commands
+- Deprecate restoring shell history feature.
 
 ### v2.4.0, 2015-02-23
 - add "tmux-test"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Optional:
 
 - [restoring vim and neovim sessions](docs/restoring_vim_and_neovim_sessions.md)
 - [restoring pane contents](docs/restoring_pane_contents.md)
-- [restoring shell history](docs/restoring_shell_history.md) (experimental)
 
 Requirements / dependencies: `tmux 1.9` or higher, `bash`.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -20,7 +20,7 @@ Currently the following hooks are supported:
 
   Called before any tmux state is altered.
 
-- `@resurrect-hook-pre-restore-history`
+- `@resurrect-hook-pre-restore-history` - deprecated
 
   Called after panes and layout have been restores, but before bash history is
   restored (if it is enabled) -- the hook is always called even if history

--- a/docs/restoring_shell_history.md
+++ b/docs/restoring_shell_history.md
@@ -1,4 +1,8 @@
-# Restoring shell history (experimental)
+# Restoring shell history (deprecated, do not use)
+
+This feature is deprecated because it's very invasive. It will be removed in
+the future with no replacement. To see problems it causes check
+[this issue](https://github.com/tmux-plugins/tmux-resurrect/issues/288).
 
 **Supported shells**: `bash` and `zsh`.
 

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -38,7 +38,7 @@ pane_contents_area_option="@resurrect-pane-contents-area"
 default_pane_contents_area="full"
 
 bash_history_option="@resurrect-save-bash-history" # deprecated
-shell_history_option="@resurrect-save-shell-history"
+shell_history_option="@resurrect-save-shell-history" # deprecated
 
 # set to 'on' to ensure panes are never ever overwritten
 overwrite_option="@resurrect-never-overwrite"


### PR DESCRIPTION
"restoring shell history" feature is very invasive and dirty. I propose
removing it in the future without the replacement.

I worry it spoils the first experience of using this plugin for users
that accidentally turn it on and don't know how to turn it off, see
https://github.com/tmux-plugins/tmux-resurrect/issues/288

Also, it hurts me to reject PRs that improve the feature.

Thoughts?