### PR TITLE
Use 'cat' binary to restore pane contents rather than (potentially) using a shell command or alias

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -108,7 +108,7 @@ tmux_default_command() {
 }
 
 pane_creation_command() {
-	echo "cat '$(pane_contents_file "restore" "${1}:${2}.${3}")'; exec $(tmux_default_command)"
+	echo "$(command -v cat) '$(pane_contents_file "restore" "${1}:${2}.${3}")'; exec $(tmux_default_command)"
 }
 
 new_window() {


### PR DESCRIPTION
`pane_creation_command` in `scripts/restore.sh` uses the string `cat` to run `/bin/cat`; however, because `pane_creation_command` is evaluated in the shell, aliases of `cat` may cause unexpected results; in my case, it runs the [`bat`][1] binary, which produces weird and garbled output. By using `command -v`, we can get the path of the `cat` binary and avoid this. (Note that we don't use `which` because `which` isn't POSIX-standard.)

[1]: https://github.com/sharkdp/bat