### PR TITLE
bash history restore

### DIFF
--- a/resurrect.alias
+++ b/resurrect.alias
@@ -1,5 +1,5 @@
 
-alias resurrect='eval $( while read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
+alias restore='eval $( while read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
       [ x$pane_index = x0 ] && echo "cd ${dir#:} ; tmux new-session -s ${session_name#:} -n ${window_name} \" tar -xzf $HOME/.tmux/resurrect/pane_contents.tar.gz -C $HOME/.tmux/resurrect/restore --to-stdout ./pane_contents/pane-${session_name#:}:${window_number}.%${pane_index} ; exec ${pane_command:-/bin/bash}\" ; cd - > /dev/null"
     done < $HOME/.tmux/resurrect/last )'
 

--- a/resurrect.alias
+++ b/resurrect.alias
@@ -1,0 +1,6 @@
+
+alias resurrect='eval $( head -1 ~/.tmux/resurrect/last | \
+    while read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
+      echo "cd ${dir#:} ; tmux new-session -s ${session_name#:} -n ${window_name} \" tar -xzf $HOME/.tmux/resurrect/pane_contents.tar.gz -C $HOME/.tmux/resurrect/restore --to-stdout ./pane_contents/pane-${session_name#:}:${window_number}.${pane_index} ; exec ${pane_command:-/bin/bash}\" ; cd - > /dev/null"
+    done )'
+

--- a/resurrect.alias
+++ b/resurrect.alias
@@ -1,6 +1,5 @@
 
-alias resurrect='eval $( head -1 ~/.tmux/resurrect/last | \
-    while read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
-      echo "cd ${dir#:} ; tmux new-session -s ${session_name#:} -n ${window_name} \" tar -xzf $HOME/.tmux/resurrect/pane_contents.tar.gz -C $HOME/.tmux/resurrect/restore --to-stdout ./pane_contents/pane-${session_name#:}:${window_number}.${pane_index} ; exec ${pane_command:-/bin/bash}\" ; cd - > /dev/null"
-    done )'
+alias resurrect='eval $( while read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
+      [ x$pane_index = x0 ] && echo "cd ${dir#:} ; tmux new-session -s ${session_name#:} -n ${window_name} \" tar -xzf $HOME/.tmux/resurrect/pane_contents.tar.gz -C $HOME/.tmux/resurrect/restore --to-stdout ./pane_contents/pane-${session_name#:}:${window_number}.%${pane_index} ; exec ${pane_command:-/bin/bash}\" ; cd - > /dev/null"
+    done < $HOME/.tmux/resurrect/last )'
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -9,6 +9,8 @@ _RESURRECT_FILE_PATH=""
 
 d=$'\t'
 
+BASE_INDEX=$( tmux show-option -gv base-index )
+
 # helper functions
 get_tmux_option() {
 	local option="$1"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -117,9 +117,9 @@ new_window() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
-	local pane_id="${session_name}:${window_number}.${pane_index}"
+	local pane_id="${session_name}:${window_number}.%${pane_index}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
-		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
+		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "%$pane_index")"
 		tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir" "$pane_creation_command"
 	else
 		tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir"
@@ -132,9 +132,9 @@ new_session() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
-	local pane_id="${session_name}:${window_number}.${pane_index}"
+	local pane_id="${session_name}:${window_number}.%${pane_index}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
-		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
+		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "%$pane_index")"
 		TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir" "$pane_creation_command"
 	else
 		TMUX="" tmux -S "$(tmux_socket)" new-session -d -s "$session_name" -n "$window_name" -c "$dir"
@@ -152,9 +152,9 @@ new_pane() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
-	local pane_id="${session_name}:${window_number}.${pane_index}"
+	local pane_id="${session_name}:${window_number}.%${pane_index}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
-		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
+		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "%$pane_index")"
 		tmux split-window -t "${session_name}:${window_number}" -c "$dir" "$pane_creation_command"
 	else
 		tmux split-window -t "${session_name}:${window_number}" -c "$dir"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -261,6 +261,16 @@ detect_if_restoring_from_scratch() {
 }
 
 detect_if_restoring_pane_contents() {
+	if [ "$( tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_id}" )" != 0:0.%0 ] ; then
+		cat <<-EOF
+			 
+			 
+			WARNING : You are not restoring from a fresh tmux session (0:0.0)
+			          Expect unexpected results
+			 
+			 
+			EOF
+	fi
 	if capture_pane_contents_option_on; then
 		cache_tmux_default_command
 		restore_pane_contents_true

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -281,8 +281,9 @@ restore_all_panes() {
 		fi
 	done < $(last_resurrect_file)
 	# This is a temporary trick, by killing the first pane before saving for proper restore
-	if ! is_pane_registered_as_existing 0 0 0; then
-		tmux kill-pane -t "0:0.0"
+	BASE_INDEX=$( tmux show-option -gv base-index )
+	if ! is_pane_registered_as_existing 0 ${BASE_INDEX} 0; then
+		tmux kill-pane -t "0:${BASE_INDEX}.%0"
 	fi
 	tmux list-panes -a -F  "#{session_name} #{window_index} #{pane_id}" | while read session_name window_number pane_id; do
 		if ! is_pane_registered_as_restored "${pane_id#%}" ; then

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -18,6 +18,7 @@ EXISTING_PANES_VAR=""
 
 RESTORING_FROM_SCRATCH="false"
 
+RESTORE_PANE_COUNT=0
 RESTORE_PANE_CONTENTS="false"
 
 is_line_type() {
@@ -117,6 +118,7 @@ new_window() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
+	RESTORE_PANE_COUNT=$[$RESTORE_PANE_COUNT+1]
 	local pane_id="${session_name}:${window_number}.%${pane_index}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
 		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "%$pane_index")"
@@ -132,6 +134,7 @@ new_session() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
+	RESTORE_PANE_COUNT=$[$RESTORE_PANE_COUNT+1]
 	local pane_id="${session_name}:${window_number}.%${pane_index}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
 		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "%$pane_index")"
@@ -152,6 +155,10 @@ new_pane() {
 	local window_name="$3"
 	local dir="$4"
 	local pane_index="$5"
+	RESTORE_PANE_COUNT=$[$RESTORE_PANE_COUNT+1]
+	if [ $RESTORE_PANE_COUNT -ne $pane_index ] ; then
+		new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
+	fi
 	local pane_id="${session_name}:${window_number}.%${pane_index}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
 		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "%$pane_index")"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -253,11 +253,11 @@ detect_if_restoring_from_scratch() {
 }
 
 detect_if_restoring_pane_contents() {
-	if [ "$( tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_id}" )" != 0:0.%0 ] ; then
+	if [ "$( tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_id}" )" != 0:${BASE_INDEX}.%0 ] ; then
 		cat <<-EOF
 			 
 			 
-			WARNING : You are not restoring from a fresh tmux session (0:0.0)
+			WARNING : You are not restoring from a fresh tmux session (0:${BASE_INDEX}.0)
 			          Expect unexpected results
 			 
 			 
@@ -283,7 +283,6 @@ restore_all_panes() {
 		fi
 	done < $(last_resurrect_file)
 	# This is a temporary trick, by killing the first pane before saving for proper restore
-	BASE_INDEX=$( tmux show-option -gv base-index )
 	if ! is_pane_registered_as_existing 0 ${BASE_INDEX} 0; then
 		tmux kill-pane -t "0:${BASE_INDEX}.%0"
 	fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -176,7 +176,6 @@ restore_pane() {
 				# happens only for the first pane if it's the only registered pane for the whole tmux server
 				local pane_id="$(tmux display-message -p -F "#{pane_id}" -t "$session_name:$window_number")"
 				new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
-				tmux kill-pane -t "$pane_id"
 			else
 				# Pane exists, no need to create it!
 				# Pane existence is registered. Later, its process also won't be restored.
@@ -260,6 +259,10 @@ restore_all_panes() {
 			restore_pane "$line"
 		fi
 	done < $(last_resurrect_file)
+	# This is a temporary trick, by killing the first pane before saving for proper restore
+	if ! is_pane_registered_as_existing 0 0 0; then
+		tmux kill-pane -t "0:0.0"
+	fi
 	if is_restoring_pane_contents; then
 		rm "$(pane_contents_dir "restore")"/*
 	fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -191,16 +191,8 @@ restore_pane() {
 		pane_full_command="$(remove_first_char "$pane_full_command")"
 		if pane_exists "$session_name" "$window_number" "$pane_index"; then
 			tmux rename-window -t "$window_number" "$window_name"
-			if is_restoring_from_scratch; then
-				# overwrite the pane
-				# happens only for the first pane if it's the only registered pane for the whole tmux server
-				local pane_id="$(tmux display-message -p -F "#{pane_id}" -t "$session_name:$window_number")"
-				new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"
-			else
-				# Pane exists, no need to create it!
-				# Pane existence is registered. Later, its process also won't be restored.
-				register_existing_pane "$session_name" "$window_number" "$pane_index"
-			fi
+			# Pane existence is registered. Later, its process also won't be restored.
+			register_existing_pane "$session_name" "$window_number" "$pane_index"
 		elif window_exists "$session_name" "$window_number"; then
 			tmux rename-window -t "$window_number" "$window_name"
 			new_pane "$session_name" "$window_number" "$window_name" "$dir" "$pane_index"

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -257,7 +257,7 @@ dump_pane_contents() {
 	local pane_contents_area="$(get_tmux_option "$pane_contents_area_option" "$default_pane_contents_area")"
 	dump_panes_raw |
 		while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
-			capture_pane_contents "${session_name}:${window_number}.${pane_index}" "$history_size" "$pane_contents_area"
+			capture_pane_contents "${session_name}:${window_number}.%${pane_index}" "$history_size" "$pane_contents_area"
 		done
 }
 

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -291,11 +291,11 @@ save_all() {
 		rm "$resurrect_file_path"
 	fi
 	if capture_pane_contents_option_on; then
-		if [[ "$( tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_id} " )" =~ "0:0.%0 " ]] ; then
+		if [[ "$( tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_id} " )" =~ "0:${BASE_INDEX}.%0 " ]] ; then
 			cat <<-EOF
 				 
 				 
-				WARNING : The initial pane (0:0.0) will not be properly restored
+				WARNING : The initial pane (0:${BASE_INDEX}.0) will not be properly restored
 				 
 				 
 				EOF

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -39,7 +39,7 @@ pane_format() {
 	format+="${delimiter}"
 	format+=":#{window_flags}"
 	format+="${delimiter}"
-	format+="#{pane_index}"
+	format+="#{pane_id}"
 	format+="${delimiter}"
 	format+=":#{pane_current_path}"
 	format+="${delimiter}"

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -295,7 +295,13 @@ save_all() {
 			cat <<-EOF
 				 
 				 
-				WARNING : The initial pane (0:${BASE_INDEX}.0) will not be properly restored
+				WARNING : The initial pane (0:${BASE_INDEX}.0) will not be properly restored by default
+				          You can restore it by defining the alias below and using it to restore your session
+				          Combination with continuum-restore setting allows full recovering with a single command
+				 
+				alias restore='eval $( while read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_full_command; do
+				      [ x$pane_index = x0 ] && echo "cd ${dir#:} ; tmux new-session -s ${session_name#:} -n ${window_name} \" tar -xzf $HOME/.tmux/resurrect/pane_contents.tar.gz -C $HOME/.tmux/resurrect/restore --to-stdout ./pane_contents/pane-${session_name#:}:${window_number}.%${pane_index} ; exec ${pane_command:-/bin/bash}\" ; cd - > /dev/null"
+				    done < $HOME/.tmux/resurrect/last )'
 				 
 				 
 				EOF

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -80,7 +80,7 @@ state_format() {
 }
 
 dump_panes_raw() {
-	tmux list-panes -a -F "$(pane_format)"
+	tmux list-panes -a -F "$(pane_format)" | sed -e 's/%//' | sort -n -k 7
 }
 
 dump_windows_raw(){

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -291,6 +291,15 @@ save_all() {
 		rm "$resurrect_file_path"
 	fi
 	if capture_pane_contents_option_on; then
+		if [[ "$( tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_id} " )" =~ "0:0.%0 " ]] ; then
+			cat <<-EOF
+				 
+				 
+				WARNING : The initial pane (0:0.0) will not be properly restored
+				 
+				 
+				EOF
+		fi
 		mkdir -p "$(pane_contents_dir "save")"
 		dump_pane_contents
 		pane_contents_create_archive


### PR DESCRIPTION
The changes basically replace the use of *pane_index* by *pane_id*. This guarantees that the environment variable `TMUX_PANE` is consistent across restores, and allows to use it as index to get separate history files for different panes.
I have this on my `.bashrc`, to set the right history filename in tmux and to update it on every command
```
HISTFILE=${HISTFILE}${TMUX_PANE:+.${TMUX_PANE#%}}
[ x$TMUX_PANE != x ] && PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND$'\n'}history -a"
```
Main problem was restoring directory & content of the very first pane (`%0'), but I've included an alias for that.