### PR TITLE
Fix a race condition when restoring pane contents

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -91,7 +91,12 @@ pane_contents_create_archive() {
 pane_content_files_restore_from_archive() {
 	local archive_file="$(pane_contents_archive_file)"
 	if [ -f "$archive_file" ]; then
-		mkdir -p "$(pane_contents_dir "restore")"
+		rm "$(pane_contents_dir "restore")"/*
+		if [ -d "$(pane_contents_dir "restore")" ]; then
+			rm -rf "$(pane_contents_dir "restore")"/*
+		else
+			mkdir -p "$(pane_contents_dir "restore")"
+		fi
 		gzip -d < "$archive_file" |
 			tar xf - -C "$(resurrect_dir)/restore/"
 	fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -264,9 +264,6 @@ restore_all_panes() {
 			restore_pane "$line"
 		fi
 	done < $(last_resurrect_file)
-	if is_restoring_pane_contents; then
-		rm "$(pane_contents_dir "restore")"/*
-	fi
 }
 
 restore_pane_layout_for_each_window() {


### PR DESCRIPTION
If the pane contents files are deleted too
quickly then pane contents restoration fails.

Cleanup previous content JiT before a restore
rather than after a restore has happened to
avoid this