### PR TITLE
Added support for saving and restoring named sessions as the default:

### DIFF
--- a/resurrect.tmux
+++ b/resurrect.tmux
@@ -21,6 +21,14 @@ set_restore_bindings() {
 	done
 }
 
+set_list_resurrect_sessions_bindings() {
+  local key_binding=$(get_tmux_option "$list_resurrect_sessions_option" "$default_list_resurrect_sessions_key")
+  local key
+  for key in $key_binding; do
+    tmux bind-key "$key" run-shell "$CURRENT_DIR/scripts/list_resurrect_sessions.sh"
+  done
+}
+
 set_default_strategies() {
 	tmux set-option -gq "${restore_process_strategy_option}irb" "default_strategy"
 	tmux set-option -gq "${restore_process_strategy_option}mosh-client" "default_strategy"
@@ -29,11 +37,13 @@ set_default_strategies() {
 set_script_path_options() {
 	tmux set-option -gq "$save_path_option" "$CURRENT_DIR/scripts/save.sh"
 	tmux set-option -gq "$restore_path_option" "$CURRENT_DIR/scripts/restore.sh"
+  tmux set-option -gq "$list_resurrect_sessions_option" "$CURRENT_DIR/scripts/list_resurrect_sessions.sh"
 }
 
 main() {
 	set_save_bindings
 	set_restore_bindings
+  set_list_resurrect_sessions_bindings
 	set_default_strategies
 	set_script_path_options
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -6,6 +6,7 @@ RESURRECT_FILE_PREFIX="tmux_resurrect"
 RESURRECT_FILE_EXTENSION="txt"
 _RESURRECT_DIR=""
 _RESURRECT_FILE_PATH=""
+CURRENT_SESSION=$( tmux display-message -p "#S" )
 
 d=$'\t'
 
@@ -113,7 +114,7 @@ _RESURRECT_DIR="$(resurrect_dir)"
 resurrect_file_path() {
 	if [ -z "$_RESURRECT_FILE_PATH" ]; then
 		local timestamp="$(date +"%Y%m%dT%H%M%S")"
-		echo "$(resurrect_dir)/${RESURRECT_FILE_PREFIX}_${timestamp}.${RESURRECT_FILE_EXTENSION}"
+		echo "$(resurrect_dir)/${CURRENT_SESSION}_${RESURRECT_FILE_PREFIX}_${timestamp}.${RESURRECT_FILE_EXTENSION}"
 	else
 		echo "$_RESURRECT_FILE_PATH"
 	fi
@@ -121,7 +122,7 @@ resurrect_file_path() {
 _RESURRECT_FILE_PATH="$(resurrect_file_path)"
 
 last_resurrect_file() {
-	echo "$(resurrect_dir)/last"
+	echo "$(resurrect_dir)/${CURRENT_SESSION}_last"
 }
 
 pane_contents_dir() {

--- a/scripts/list_resurrect_sessions.sh
+++ b/scripts/list_resurrect_sessions.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"  && pwd )"
+
+source "$CURRENT_DIR/variables.sh"
+source "$CURRENT_DIR/helpers.sh"
+
+sessions=`ls $(resurrect_dir)`
+
+main() {
+  echo "Available sessions for restore:"
+  echo
+  for session in $sessions; do
+    if [[ "$session" =~ _last$ ]]; then
+      echo "${session%%_last}"
+    fi
+  done
+}
+
+main

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -7,6 +7,9 @@ default_restore_key="C-r"
 restore_option="@resurrect-restore"
 restore_path_option="@resurrect-restore-script-path"
 
+default_list_resurrect_sessions_key="C-l"
+list_resurrect_sessions_option="@resurrect-list-sessions"
+
 # default processes that are restored
 default_proc_list_option="@resurrect-default-processes"
 default_proc_list='vi vim view nvim emacs man less more tail top htop irssi weechat mutt'


### PR DESCRIPTION
  1. The default session, "0" mimics the current behaviour, more or
     less.
  2. `C-l` in an active tmux session will list all the saved past
     "sessions" that you can choose to restore from/save to.
  3. If the target session is already running, simply attach to it, and
     save and restore as usual.
  4. If the target session is not running, simply rename the current
     session to the target session name, and then save and restore as
     usual.
  5. Alternately, simply start off with the session in mind:
     `tmux new -s <session-name>`, and then save and restore as
     usual.