### PR TITLE
enable the tilde expansion ( aka ~ ) into $HOME in paths

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# EditorConfig is awesome: http://EditorConfig.org
+# keep consistent coding styles for different file types
+
+# this is the top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.sh]
+tab_width = 4
+indent_style = tab
+indent_size = 4
+
+[COMMIT_EDITMSG]
+max_line_length = 0
+
+[*.{md,txt}]
+indent_size = 2
+indent_style = space
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -130,6 +130,7 @@ new_window() {
 	local dir="$4"
 	local pane_index="$5"
 	local pane_id="${session_name}:${window_number}.${pane_index}"
+	dir="${dir/#\~/$HOME}"
 	if is_restoring_pane_contents && pane_contents_file_exists "$pane_id"; then
 		local pane_creation_command="$(pane_creation_command "$session_name" "$window_number" "$pane_index")"
 		tmux new-window -d -t "${session_name}:${window_number}" -n "$window_name" -c "$dir" "$pane_creation_command"


### PR DESCRIPTION
which is at least pretty value-able because of mac + vm with shared $HOME ... that is I could easily restore the same sessions between the shell in the host and the guest ...  