### PR TITLE
Allow simultaneously working on and maintaining multiple resurrect sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### master
+- Added support for simultaneously working on, and maintaining multiple independent resurrect sessions
+- Option @resurrect-dir has been changed from global to session local (use without -g)
 - save and restore tmux pane contents (@laomaiweng)
 - update tmux-test to solve issue with recursing git submodules in that project
 - set options quietly in `resurrect.tmux` script

--- a/docs/save_dir.md
+++ b/docs/save_dir.md
@@ -3,13 +3,13 @@
 By default Tmux environment is saved to a file in `~/.tmux/resurrect` dir.
 Change this with:
 
-    set -g @resurrect-dir '/some/path'
+    set @resurrect-dir '/some/path'
 
 Using environment variables or shell interpolation in this option is not
 allowed as the string is used literally. So the following won't do what is
 expected:
 
-    set -g @resurrect-dir '/path/$MY_VAR/$(some_executable)'
+    set @resurrect-dir '/path/$MY_VAR/$(some_executable)'
 
 Only the following variables and special chars are allowed:
 `$HOME`, `$HOSTNAME`, and `~`.

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,7 +13,8 @@ d=$'\t'
 get_tmux_option() {
 	local option="$1"
 	local default_value="$2"
-	local option_value=$(tmux show-option -gqv "$option")
+    local showoptionswitch="${3:--gqv}"
+	local option_value=$(tmux show-option $showoptionswitch "$option")
 	if [ -z "$option_value" ]; then
 		echo "$default_value"
 	else
@@ -101,7 +102,7 @@ pane_content_files_restore_from_archive() {
 
 resurrect_dir() {
 	if [ -z "$_RESURRECT_DIR" ]; then
-		local path="$(get_tmux_option "$resurrect_dir_option" "$default_resurrect_dir")"
+		local path="$(get_tmux_option "$resurrect_dir_option" "$default_resurrect_dir" "-qv")"
 		# expands tilde, $HOME and $HOSTNAME if used in @resurrect-dir
 		echo "$path" | sed "s,\$HOME,$HOME,g; s,\$HOSTNAME,$(hostname),g; s,\~,$HOME,g"
 	else

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -80,11 +80,11 @@ state_format() {
 }
 
 dump_panes_raw() {
-	tmux list-panes -a -F "$(pane_format)"
+	tmux list-panes -a -F "$(pane_format)" -f "#{?session_group_attached,#{session_group_attached},#{session_attached}}" 
 }
 
 dump_windows_raw(){
-	tmux list-windows -a -F "$(window_format)"
+	tmux list-windows -a -F "$(window_format)" -f "#{?session_group_attached,#{session_group_attached},#{session_attached}}" 
 }
 
 toggle_window_zoom() {
@@ -197,7 +197,7 @@ get_alternate_window_index() {
 dump_grouped_sessions() {
 	local current_session_group=""
 	local original_session
-	tmux list-sessions -F "$(grouped_sessions_format)" |
+	tmux list-sessions -F "$(grouped_sessions_format)" -f "#{?session_group_attached,#{session_group_attached},#{session_attached}}" |
 		grep "^1" |
 		cut -c 3- |
 		sort |


### PR DESCRIPTION
Changed helpers.sh and save.sh to allow simultaneously working on and maintaining multiple independent resurrect session files. Should resolve #246, and #389. Description of changes: 1) File helpers.sh: function get_tmux_option() now has an optional 3rd argument that can be used to pass custom option to tmux show-option command. This is used in function resurrect_dir() to pickup session local value of @resurrect-dir instead of using a global @resurrect-dir. Using session local values for @resurrect-dir is needed to maintain and simultaneously work with multiple different resurrect session files. 2) File save.sh: a missing filter has been applied to tmux list-sessions, tmux-listpanes, and tmux-listwindows. The filter does this: at time of saving a resurrect session, it checks if the current (attached) session is in a group. If that is true then the filter passes only sessions/panes/windows that belong to current (attached) group. Thus only current group's sessions/panes/windows are saved. If that is false, then filter passes only current (attached) session's panes and windows. Thus only current (attached) session's panes/windows are saved. Both changes to 1) and 2) together are required to enable working on multiple different resurrect sessions simultaneously, and independently. The effect of maintaining, working on multiple different resurrect sessions simultaneously can be achieved by the user by setting different values for @resurrect-dir. I confirm testing new capability.