### PR TITLE
Preserve the value of automatic-rename option

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -292,10 +292,11 @@ handle_session_0() {
 	fi
 }
 
-restore_pane_layout_for_each_window() {
+restore_pane_layout_and_autonaming_for_each_window() {
 	\grep '^window' $(last_resurrect_file) |
-		while IFS=$d read line_type session_name window_number window_active window_flags window_layout; do
+		while IFS=$d read line_type session_name window_number window_active window_flags window_layout automatic_rename; do
 			tmux select-layout -t "${session_name}:${window_number}" "$window_layout"
+			tmux set-option -t "${session_name}:${window_number}" automatic-rename "$automatic_rename"
 		done
 }
 
@@ -376,7 +377,7 @@ main() {
 		execute_hook "pre-restore-all"
 		restore_all_panes
 		handle_session_0
-		restore_pane_layout_for_each_window >/dev/null 2>&1
+		restore_pane_layout_and_autonaming_for_each_window >/dev/null 2>&1
 		execute_hook "pre-restore-history"
 		if save_shell_history_option_on; then
 			restore_shell_history

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -67,7 +67,7 @@ window_format() {
 	format+="${delimiter}"
 	format+="#{window_layout}"
 	format+="${delimiter}"
-	format+="#{?automatic-rename,yes,no}"
+	format+="#{?automatic-rename,on,off}"
 	echo "$format"
 }
 

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -66,6 +66,8 @@ window_format() {
 	format+=":#{window_flags}"
 	format+="${delimiter}"
 	format+="#{window_layout}"
+	format+="${delimiter}"
+	format+="#{?automatic-rename,yes,no}"
 	echo "$format"
 }
 
@@ -240,12 +242,12 @@ dump_panes() {
 
 dump_windows() {
 	dump_windows_raw |
-		while IFS=$d read line_type session_name window_index window_active window_flags window_layout; do
+		while IFS=$d read line_type session_name window_index window_active window_flags window_layout automatic_rename; do
 			# not saving windows from grouped sessions
 			if is_session_grouped "$session_name"; then
 				continue
 			fi
-			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}"
+			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}${d}${automatic_rename}"
 		done
 }
 


### PR DESCRIPTION
When windows are renamed while restoring tmux, the value of
automatic-rename is set to off, which might not be desired.

Therefore, the original value of the automatic-rename option for each
window is now saved and set again while restoring. This means that
windows intended to have fixed names will continue to have fixed names,
while windows intended to have automatic-rename will continue to have
automatic-rename.