### PR TITLE
[WIP] Fix auto-rename after restore

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -172,7 +172,7 @@ new_pane() {
 	else
 		tmux split-window -t "${session_name}:${window_number}" -c "$dir"
 	fi
-	tmux rename-window -t "${session_name}:${window_number}" "$window_name"
+	tmux rename-window -t "${session_name}:${window_number}"
 	# minimize window so more panes can fit
 	tmux resize-pane  -t "${session_name}:${window_number}" -U "999"
 }

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -33,8 +33,6 @@ pane_format() {
 	format+="${delimiter}"
 	format+="#{window_index}"
 	format+="${delimiter}"
-	format+=":#{window_name}"
-	format+="${delimiter}"
 	format+="#{window_active}"
 	format+="${delimiter}"
 	format+=":#{window_flags}"
@@ -53,6 +51,18 @@ pane_format() {
 	echo "$format"
 }
 
+get_auto_rename() {
+    local res=$(tmux show -w automatic-rename)
+    if [[ -z $res ]] || [[ $res == "automatic-rename off" ]]
+    then
+        echo ":#{window_name}"
+    else
+        echo "#{window_name}"
+    fi
+}
+
+get_auto_rename
+
 window_format() {
 	local format
 	format+="window"
@@ -61,7 +71,9 @@ window_format() {
 	format+="${delimiter}"
 	format+="#{window_index}"
 	format+="${delimiter}"
-	format+="#{window_active}"
+	format+=":#{window_name}"
+	format+="${delimiter}"
+    format+="#{window_active}"
 	format+="${delimiter}"
 	format+=":#{window_flags}"
 	format+="${delimiter}"
@@ -320,4 +332,4 @@ main() {
 		fi
 	fi
 }
-main
+# main


### PR DESCRIPTION
#222
#57

Hi @bruno-,

I was busy with work recently, but I should be able to knock out an initial solution in the next few days. I'm hoping to maintain this draft and collaborate on the fix until we get it right, so this PR is only draft for the time being. 

One of the first things I checked is how automatic-rename behaves given various settings. There are three potential outputs of `tmux show -w automatic-rename` that I noted:

1. Empty -- As you pointed out, this can be reproduced by first running `tmux set -u -w automatic-rename
`
2. `automatic-rename on` -- this can be reproduced by first running `tmux set -w automatic-rename on`
3. `automatic-rename off` -- this can be reproduced by first running `tmux set -w automatic-rename off`

Since we want to save the window-level values based on the result of  `tmux set -u -w automatic-rename`, I implemented a function following those three cases.

Please let me know if this is what we want. 

Thank you!