### PR TITLE
Maintain the value of automatic-rename

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -286,6 +286,7 @@ handle_session_0() {
 }
 
 restore_window_properties() {
+	local window_name
 	\grep '^window' $(last_resurrect_file) |
 		while IFS=$d read line_type session_name window_number window_name window_active window_flags window_layout automatic_rename; do
 			window_name="$(remove_first_char "$window_name")"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -292,10 +292,15 @@ handle_session_0() {
 	fi
 }
 
-restore_pane_layout_for_each_window() {
+restore_pane_layout_and_autonaming_for_each_window() {
 	\grep '^window' $(last_resurrect_file) |
-		while IFS=$d read line_type session_name window_number window_active window_flags window_layout; do
+		while IFS=$d read line_type session_name window_number window_active window_flags window_layout automatic_rename; do
 			tmux select-layout -t "${session_name}:${window_number}" "$window_layout"
+			if [ "${automatic_rename}" = ":" ]; then
+				tmux set-option -u -t "${session_name}:${window_number}" automatic-rename
+			else
+				tmux set-option -t "${session_name}:${window_number}" automatic-rename "$automatic_rename"
+			fi
 		done
 }
 
@@ -376,7 +381,7 @@ main() {
 		execute_hook "pre-restore-all"
 		restore_all_panes
 		handle_session_0
-		restore_pane_layout_for_each_window >/dev/null 2>&1
+		restore_pane_layout_and_autonaming_for_each_window >/dev/null 2>&1
 		execute_hook "pre-restore-history"
 		if save_shell_history_option_on; then
 			restore_shell_history

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -355,7 +355,7 @@ restore_grouped_sessions() {
 }
 
 restore_active_and_alternate_windows() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^window/ && $5 ~ /[*-]/ { print $2, $4, $3; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t"; OFS="\t" } /^window/ && $6 ~ /[*-]/ { print $2, $4, $3; }' $(last_resurrect_file) |
 		sort -u |
 		while IFS=$d read session_name active_window window_number; do
 			tmux switch-client -t "${session_name}:${window_number}"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -300,7 +300,7 @@ restore_window_properties() {
 }
 
 restore_shell_history() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ { print $2, $3, $7, $10; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ { print $2, $3, $6, $9; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number pane_index pane_command; do
 			if ! is_pane_registered_as_existing "$session_name" "$window_number" "$pane_index"; then
 				local pane_id="$session_name:$window_number.$pane_index"
@@ -321,7 +321,7 @@ restore_shell_history() {
 restore_all_pane_processes() {
 	if restore_pane_processes_enabled; then
 		local pane_full_command
-		awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $11 !~ "^:$" { print $2, $3, $7, $8, $11; }' $(last_resurrect_file) |
+		awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $10 !~ "^:$" { print $2, $3, $6, $7, $10; }' $(last_resurrect_file) |
 			while IFS=$d read -r session_name window_number pane_index dir pane_full_command; do
 				dir="$(remove_first_char "$dir")"
 				pane_full_command="$(remove_first_char "$pane_full_command")"
@@ -331,7 +331,7 @@ restore_all_pane_processes() {
 }
 
 restore_active_pane_for_each_window() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $9 == 1 { print $2, $3, $7; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $8 == 1 { print $2, $3, $6; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number active_pane; do
 			tmux switch-client -t "${session_name}:${window_number}"
 			tmux select-pane -t "$active_pane"
@@ -339,7 +339,7 @@ restore_active_pane_for_each_window() {
 }
 
 restore_zoomed_windows() {
-	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $6 ~ /Z/ && $9 == 1 { print $2, $3; }' $(last_resurrect_file) |
+	awk 'BEGIN { FS="\t"; OFS="\t" } /^pane/ && $5 ~ /Z/ && $8 == 1 { print $2, $3; }' $(last_resurrect_file) |
 		while IFS=$d read session_name window_number; do
 			tmux resize-pane -t "${session_name}:${window_number}" -Z
 		done

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -259,14 +259,14 @@ dump_state() {
 dump_pane_contents() {
 	local pane_contents_area="$(get_tmux_option "$pane_contents_area_option" "$default_pane_contents_area")"
 	dump_panes_raw |
-		while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
+		while IFS=$d read line_type session_name window_number window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
 			capture_pane_contents "${session_name}:${window_number}.${pane_index}" "$history_size" "$pane_contents_area"
 		done
 }
 
 dump_shell_history() {
 	dump_panes |
-		while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command full_command; do
+		while IFS=$d read line_type session_name window_number window_active window_flags pane_index dir pane_active pane_command full_command; do
 			save_shell_history "$session_name:$window_number.$pane_index" "$pane_command" "$full_command"
 		done
 }

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -245,7 +245,10 @@ dump_windows() {
 			if is_session_grouped "$session_name"; then
 				continue
 			fi
-			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}"
+			automatic_rename="$(tmux show-window-options -vt "${session_name}:${window_index}" automatic-rename)"
+			# If the option was unset, place the ":" placeholder instead.
+			[ -z "${automatic_rename}" ] && automatic_rename=":"
+			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}${d}${automatic_rename}"
 		done
 }
 

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -33,8 +33,6 @@ pane_format() {
 	format+="${delimiter}"
 	format+="#{window_index}"
 	format+="${delimiter}"
-	format+=":#{window_name}"
-	format+="${delimiter}"
 	format+="#{window_active}"
 	format+="${delimiter}"
 	format+=":#{window_flags}"
@@ -60,6 +58,8 @@ window_format() {
 	format+="#{session_name}"
 	format+="${delimiter}"
 	format+="#{window_index}"
+	format+="${delimiter}"
+	format+="#{window_name}"
 	format+="${delimiter}"
 	format+="#{window_active}"
 	format+="${delimiter}"
@@ -227,20 +227,20 @@ fetch_and_dump_grouped_sessions(){
 dump_panes() {
 	local full_command
 	dump_panes_raw |
-		while IFS=$d read line_type session_name window_number window_name window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
+		while IFS=$d read line_type session_name window_number window_active window_flags pane_index dir pane_active pane_command pane_pid history_size; do
 			# not saving panes from grouped sessions
 			if is_session_grouped "$session_name"; then
 				continue
 			fi
 			full_command="$(pane_full_command $pane_pid)"
 			dir=$(echo $dir | sed 's/ /\\ /') # escape all spaces in directory path
-			echo "${line_type}${d}${session_name}${d}${window_number}${d}${window_name}${d}${window_active}${d}${window_flags}${d}${pane_index}${d}${dir}${d}${pane_active}${d}${pane_command}${d}:${full_command}"
+			echo "${line_type}${d}${session_name}${d}${window_number}${d}${window_active}${d}${window_flags}${d}${pane_index}${d}${dir}${d}${pane_active}${d}${pane_command}${d}:${full_command}"
 		done
 }
 
 dump_windows() {
 	dump_windows_raw |
-		while IFS=$d read line_type session_name window_index window_active window_flags window_layout; do
+		while IFS=$d read line_type session_name window_index window_name window_active window_flags window_layout; do
 			# not saving windows from grouped sessions
 			if is_session_grouped "$session_name"; then
 				continue
@@ -248,7 +248,7 @@ dump_windows() {
 			automatic_rename="$(tmux show-window-options -vt "${session_name}:${window_index}" automatic-rename)"
 			# If the option was unset, place the ":" placeholder instead.
 			[ -z "${automatic_rename}" ] && automatic_rename=":"
-			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_active}${d}${window_flags}${d}${window_layout}${d}${automatic_rename}"
+			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_name}${d}${window_active}${d}${window_flags}${d}${window_layout}${d}${automatic_rename}"
 		done
 }
 

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -59,7 +59,7 @@ window_format() {
 	format+="${delimiter}"
 	format+="#{window_index}"
 	format+="${delimiter}"
-	format+="#{window_name}"
+	format+=":#{window_name}"
 	format+="${delimiter}"
 	format+="#{window_active}"
 	format+="${delimiter}"


### PR DESCRIPTION
An alternative implementation of #399.

Handles the unset case - if it was initially unset, it is kept that way.

Fixes #57.
Fixes #343.