### PR TITLE
Fix #141

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -270,9 +270,6 @@ restore_all_panes() {
 			restore_pane "$line"
 		fi
 	done < $(last_resurrect_file)
-	if is_restoring_pane_contents; then
-		rm "$(pane_contents_dir "restore")"/*
-	fi
 }
 
 handle_session_0() {
@@ -375,6 +372,12 @@ restore_active_and_alternate_sessions() {
 	done < $(last_resurrect_file)
 }
 
+cleanup_restored_pane_contents() {
+	if is_restoring_pane_contents; then
+		rm "$(pane_contents_dir "restore")"/*
+	fi
+}
+
 main() {
 	if supported_tmux_version_ok && check_saved_session_exists; then
 		start_spinner "Restoring..." "Tmux restore complete!"
@@ -394,6 +397,7 @@ main() {
 		restore_grouped_sessions  # also restores active and alt windows for grouped sessions
 		restore_active_and_alternate_windows
 		restore_active_and_alternate_sessions
+		cleanup_restored_pane_contents
 		execute_hook "post-restore-all"
 		stop_spinner
 		display_message "Tmux restore complete!"


### PR DESCRIPTION
As I mentioned in [#141](https://github.com/tmux-plugins/tmux-resurrect/issues/141#issuecomment-997377179), the issue apparently happens when using fish as the default shell. This commit fixes this issue by postponing `restore/pane_contents` clean-up after calling `restore_active_pane_for_each_window` (scripts/restore.sh:392). It might also fix #192.