### PR TITLE
Fix for restoring bash history

### DIFF
--- a/docs/restoring_bash_history.md
+++ b/docs/restoring_bash_history.md
@@ -19,13 +19,13 @@ mkdir -p "${HISTS_DIR}"
 if [ -n "${TMUX_PANE}" ]; then
 
   # Check if we've already set this pane title
-  pane_id=$(tmux display-message -p '#{pane_title}')
+  pane_id=$(tmux display -pt "${TMUX_PANE:?}" "#{pane_title}")
   if [[ $pane_id != "$pane_id_prefix"* ]]; then
 
     # if not, set it to a random ID
     random_id=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 16)
     printf "\033]2;$pane_id_prefix$random_id\033\\"
-    pane_id=$(tmux display-message -p '#{pane_title}')
+    pane_id=$(tmux display -pt "${TMUX_PANE:?}" "#{pane_title}")
   fi
 
   # use the pane's random ID for the HISTFILE


### PR DESCRIPTION
This command seems to be more reliable - the other one I think grabs the "active" pane's title, which doesn't always sync up.