### PR TITLE
Save single session

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Automatic restoring and continuous saving of tmux env is also possible with
 
 ### Key bindings
 
-- `prefix + Ctrl-s` - save
+- `prefix + Ctrl-s` - save all sessions
+- `prefix + Ctrl-t` - save current session
 - `prefix + Ctrl-r` - restore
 
 ### About

--- a/docs/custom_key_bindings.md
+++ b/docs/custom_key_bindings.md
@@ -2,10 +2,12 @@
 
 The default key bindings are:
 
-- `prefix + Ctrl-s` - save
+- `prefix + Ctrl-s` - save all sessions
+- `prefix + Ctrl-t` - save current session
 - `prefix + Ctrl-r` - restore
 
 To change these, add to `.tmux.conf`:
 
     set -g @resurrect-save 'S'
+    set -g @resurrect-save-current 'T'
     set -g @resurrect-restore 'R'

--- a/resurrect.tmux
+++ b/resurrect.tmux
@@ -13,6 +13,14 @@ set_save_bindings() {
 	done
 }
 
+set_save_current_bindings() {
+	local key_bindings=$(get_tmux_option "$save_current_option" "$default_save_current_key")
+	local key
+	for key in $key_bindings; do
+		tmux bind-key "$key" run-shell "$CURRENT_DIR/scripts/save.sh -t #S"
+	done
+}
+
 set_restore_bindings() {
 	local key_bindings=$(get_tmux_option "$restore_option" "$default_restore_key")
 	local key
@@ -33,6 +41,7 @@ set_script_path_options() {
 
 main() {
 	set_save_bindings
+	set_save_current_bindings
 	set_restore_bindings
 	set_default_strategies
 	set_script_path_options

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -10,8 +10,18 @@ source "$CURRENT_DIR/spinner_helpers.sh"
 d=$'\t'
 delimiter=$'\t'
 
-# if "quiet" script produces no output
-SCRIPT_OUTPUT="$1"
+while getopts "t:q" opt; do
+	case "$opt" in
+		t)
+			TARGET_SESSION="$OPTARG"
+			tmux has-session -t "$TARGET_SESSION" ||
+				exit 1
+			;;
+		q)
+			SCRIPT_OUTPUT="quiet"
+			;;
+	esac
+done
 
 grouped_sessions_format() {
 	local format
@@ -81,12 +91,24 @@ state_format() {
 	echo "$format"
 }
 
+session_selector_windows() {
+	[ -z "$TARGET_SESSION" ] &&
+		echo "-a" ||
+		echo "-t $TARGET_SESSION"
+}
+
+session_selector_panes() {
+	[ -z "$TARGET_SESSION" ] &&
+		echo "-a" ||
+		echo "-s -t $TARGET_SESSION"
+}
+
 dump_panes_raw() {
-	tmux list-panes -a -F "$(pane_format)"
+	tmux list-panes $(session_selector_panes) -F "$(pane_format)"
 }
 
 dump_windows_raw(){
-	tmux list-windows -a -F "$(window_format)"
+	tmux list-windows $(session_selector_windows) -F "$(window_format)"
 }
 
 toggle_window_zoom() {
@@ -215,6 +237,7 @@ dump_windows() {
 }
 
 dump_state() {
+	[[ -z "$TARGET_SESSION" ]] || return
 	tmux display-message -p "$(state_format)"
 }
 

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -91,24 +91,16 @@ state_format() {
 	echo "$format"
 }
 
-session_selector_windows() {
-	[ -z "$TARGET_SESSION" ] &&
-		echo "-a" ||
-		echo "-t $TARGET_SESSION"
-}
-
-session_selector_panes() {
-	[ -z "$TARGET_SESSION" ] &&
-		echo "-a" ||
-		echo "-s -t $TARGET_SESSION"
-}
-
 dump_panes_raw() {
-	tmux list-panes $(session_selector_panes) -F "$(pane_format)"
+	[ -z "$TARGET_SESSION" ] &&
+		tmux list-panes -a -F "$(pane_format)" ||
+		tmux list-panes -s -t "$TARGET_SESSION" -F "$(pane_format)"
 }
 
 dump_windows_raw(){
-	tmux list-windows $(session_selector_windows) -F "$(window_format)"
+	[ -z "$TARGET_SESSION" ] &&
+		tmux list-windows -a -F "$(window_format)" ||
+		tmux list-windows -t "$TARGET_SESSION" -F "$(window_format)"
 }
 
 toggle_window_zoom() {

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -3,6 +3,9 @@ default_save_key="C-s"
 save_option="@resurrect-save"
 save_path_option="@resurrect-save-script-path"
 
+default_save_current_key="C-t"
+save_current_option="@resurrect-save-current"
+
 default_restore_key="C-r"
 restore_option="@resurrect-restore"
 restore_path_option="@resurrect-restore-script-path"


### PR DESCRIPTION
Dear maintainer,

Thank you for your work on `tmux-resurrect` and for taking time to consider my pull request. In short, it adds the following features:
1. `scripts/save.sh` now allows saving only a single session, using the `-t` parameter. For example: `./save.sh -t my_session`
2. There is now a new keybind, `C-t`, which saves only the currently focused session. This keybind is documented in `docs/custom_key_bindings.md` and `README.md`
3. When using the above features, the `state` line is not written to the save file. This is to avoid errors when restoring, in case the session that was in focus when saving is different to the session that was saved.

Unfortunately, there is one breaking change: due to the nature of `getopts`, suppressing the output of `save.sh` is now done with the `-q` flag (i.e. `./save-sh -q`), instead of the `quiet` argument.

This pull request should resolve issue #427 .