### PR TITLE
Use bash subshell for procfs interpolation of cmdline file

### DIFF
--- a/save_command_strategies/linux_procfs.sh
+++ b/save_command_strategies/linux_procfs.sh
@@ -13,7 +13,10 @@ exit_safely_if_empty_ppid() {
 
 full_command() {
 	[[ -z "$COMMAND_PID" ]] && exit 0
-	cat /proc/${COMMAND_PID}/cmdline | xargs -0 printf "%q "
+    # See: https://unix.stackexchange.com/a/567021
+    # Avoid complications with system printf by using bash subshell interpolation.
+    # This will properly escape sequences and null in cmdline.
+    cat /proc/${COMMAND_PID}/cmdline | xargs -0 bash -c 'printf "%q " "$0" "$@"'
 }
 
 main() {


### PR DESCRIPTION
See #449 

Base stackexchange reasoning: https://unix.stackexchange.com/questions/243142/how-to-show-quoted-command-list/567021#567021

Further reading: https://unix.stackexchange.com/questions/432419/unexpected-non-null-encoding-of-proc-pid-cmdline/432681#432681

Testing
```
$ pgrep -a vim
70431 vim --cmd set pythonthreehome=/project/env/altternative/python3.8 /home/mdeguzis/.tmux.conf
74234 vim --cmd set pythonthreehome=/project/env/altternative/python3.8 save_command_strategies/linux_procfs.sh
91608 vim --cmd set pythonthreehome=/project/env/altternative/python3.8 --cmd set pythonthreehome=/apollo

$ COMMAND_PID=7043
$ cat /proc/${COMMAND_PID}/cmdline | xargs -0 bash -c 'printf "%q " "$0" "$@"'

# Produces totally valid and usable command:
vim --cmd set\ pythonthreehome=/project/env/altternative/python3.8 /home/mdeguzis/.tmux.conf
```

