### PR TITLE
ps.sh: fix ps arguments to work for busybox

### DIFF
--- a/save_command_strategies/ps.sh
+++ b/save_command_strategies/ps.sh
@@ -11,7 +11,7 @@ exit_safely_if_empty_ppid() {
 }
 
 full_command() {
-	ps -ao "ppid command" |
+	ps -ao "ppid,args" |
 		sed "s/^ *//" |
 		grep "^${PANE_PID}" |
 		cut -d' ' -f2-


### PR DESCRIPTION
Use the format specifier `'ppid,args'` instead of `'ppid command'`. POSIX allows either spaces or commas as separators, but busybox only allows commas. Furthermore, `args` is [recognized by POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html) while `command` is not. On implementations of ps that do recognize `command`, it is simply an alias for `args`, e.g. [Debian](https://manpages.debian.org/bullseye/procps/ps.1.en.html) and [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=ps).