### PR TITLE
use XDG_DATA_HOME for resurrect-dir path

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,4 +1,8 @@
-default_resurrect_dir="$HOME/.tmux/resurrect"
+if [ -d "$HOME/.tmux/resurrect" ]; then
+        default_resurrect_dir="$HOME/.tmux/resurrect"
+else
+        default_resurrect_dir="${XDG_DATA_HOME:-$HOME/.local/share}"/tmux/resurrect
+fi
 resurrect_dir_option="@resurrect-dir"
 
 SUPPORTED_VERSION="1.9"


### PR DESCRIPTION
To keep backwards compatibility, only consider XDG_DATA_HOME if `$HOME/.tmux/resurrect` is not found. Fixes #348

Not sure if that's all it needs. But anyway, I think this is an small change to benefit many XDG standard lovers, it should be supported sooner the better.