### PR TITLE
fix(#452): clear pane contents on restore

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -202,6 +202,7 @@ restore_pane() {
 		fi
 		# set pane title
 		tmux select-pane -t "$session_name:$window_number.$pane_index" -T "$pane_title"
+		tmux send-keys -t "$session_name:$window_number.$pane_index" 'c-l'
 	done < <(echo "$pane")
 }
 


### PR DESCRIPTION
This seems to be a naive (but fully functional) approach to resolve #452.