### PR TITLE
Restore with command arguments misc fixes

### DIFF
--- a/docs/restoring_programs.md
+++ b/docs/restoring_programs.md
@@ -28,6 +28,10 @@ contains space-separated list of additional programs to restore.
 
         set -g @resurrect-processes 'some_program "grunt->grunt development"'
 
+- Use `*` to expand the arguments from the saved command when restoring:
+
+        set -g @resurrect-processes 'some_program "~rails server->rails server *"'
+
 - Don't restore any programs:
 
         set -g @resurrect-processes 'false'
@@ -95,6 +99,20 @@ command name".
 
 Full (long) process name is now ignored and you'll see just `rails server` in
 the command line when the program is restored.
+
+> What is asterisk `*` and why is it used?
+
+(Please read the above clarifications about tilde `~` and arrow `->`).
+
+Continuing with the `rails server` example, you might have added flags for e.g.
+verbose logging, but with the above configuration, the flags would be lost.
+
+To preserve the command arguments when restoring, use the asterisk `*`: (**note**: there **must** be a space before `*`)
+
+    set -g @resurrect-processes '"~rails server->rails server *"'
+
+This option says: "when this process is restored use `rails server` as the
+command name, but preserve its arguments".
 
 > Now I understand the tilde and the arrow, but things still don't work for me
 

--- a/scripts/process_restore_helpers.sh
+++ b/scripts/process_restore_helpers.sh
@@ -121,7 +121,7 @@ _get_command_arguments() {
 	if _proc_starts_with_tildae "$match"; then
 		match="$(remove_first_char "$match")"
 	fi
-	echo "$pane_full_command" | sed "s,^.*${match}[^ ]* ,,"
+	echo "$pane_full_command" | sed "s,^.*${match}[^ ]* *,,"
 }
 
 _get_proc_restore_command() {

--- a/scripts/process_restore_helpers.sh
+++ b/scripts/process_restore_helpers.sh
@@ -132,7 +132,7 @@ _get_proc_restore_command() {
 	if [[ "$restore_element" =~ " ${inline_strategy_arguments_token}" ]]; then
 		# replaces "%" with command arguments
 		local command_arguments="$(_get_command_arguments "$pane_full_command" "$match")"
-		echo "$restore_element" | sed "s/${inline_strategy_arguments_token}/${command_arguments}/"
+		echo "$restore_element" | sed "s,${inline_strategy_arguments_token},${command_arguments},"
 	else
 		echo "$restore_element"
 	fi


### PR DESCRIPTION
- Fix command being used as argument when there's no arguments (for example `vim` would turn into `vim vim`), due to the regex for removing the command name expecting there to be a trailing space (as there normally would be if there were arguments).
- Fix command and arguments being incorrectly parsed when the arguments contain a path, as the sed delimiter was `/`.
- Add docs on this restore option.

Fixes: #468 