### PR TITLE
Update description of default session location

### DIFF
--- a/docs/restoring_previously_saved_environment.md
+++ b/docs/restoring_previously_saved_environment.md
@@ -1,7 +1,8 @@
 # Restoring previously saved environment
 
 None of the previous saves are deleted (unless you explicitly do that). All save
-files are kept in `~/.tmux/resurrect/` directory.<br/>
+files are kept in `~/.tmux/resurrect/` directory, or `~/.local/share/tmux/resurrect`
+(unless `${XDG_DATA_HOME}` says otherwise).<br/>
 Here are the steps to restore to a previous point in time:
 
 - make sure you start this with a "fresh" tmux instance


### PR DESCRIPTION
When explaining about session restore procedure, include all locations where the sessions can be stored. 

- Include alternate location `~/.local/share/tmux/resurrect/`
- Include reference to `${XDB_DATA_HOME}` env variable