### PR TITLE
feat(session): preserve user session order on save. closes #388

### DIFF
--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -27,6 +27,8 @@ grouped_sessions_format() {
 
 pane_format() {
 	local format
+	format+="#{session_id}"
+	format+="${delimiter}"
 	format+="pane"
 	format+="${delimiter}"
 	format+="#{session_name}"
@@ -55,6 +57,8 @@ pane_format() {
 
 window_format() {
 	local format
+	format+="#{session_id}"
+	format+="${delimiter}"
 	format+="window"
 	format+="${delimiter}"
 	format+="#{session_name}"
@@ -82,11 +86,11 @@ state_format() {
 }
 
 dump_panes_raw() {
-	tmux list-panes -a -F "$(pane_format)"
+	tmux list-panes -a -F "$(pane_format)" | sort -k1 | cut -f2-
 }
 
 dump_windows_raw(){
-	tmux list-windows -a -F "$(window_format)"
+	tmux list-windows -a -F "$(window_format)" | sort -k1 | cut -f2-
 }
 
 toggle_window_zoom() {


### PR DESCRIPTION
tmux-resurrect saves sessions alphabetically using session names.

This commit changes the order by sorting numerically using session id, preserving user's session order.

This change closes #388.