### PR TITLE
Per-server (per-socket) sessions

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -98,7 +98,7 @@ pane_content_files_restore_from_archive() {
 
 resurrect_dir() {
 	if [ -z "$_RESURRECT_DIR" ]; then
-		local path="$(get_tmux_option "$resurrect_dir_option" "$default_resurrect_dir")"
+		local path="$(get_tmux_option "$resurrect_dir_option" "$default_resurrect_dir")/$(basename $(tmux display-message -p -F "#{socket_path}"))"
 		# expands tilde, $HOME and $HOSTNAME if used in @resurrect-dir
 		echo "$path" | sed "s,\$HOME,$HOME,g; s,\$HOSTNAME,$(hostname),g; s,\~,$HOME,g"
 	else


### PR DESCRIPTION
BREAKING: may break existing sessions or integrations, since session save location is changed. See how to migrate below.

Tested with macOS Ventura, tmux 3.3a, TPM.

Migration path:

1. Check and back up the current contents of your resurrect directory (it’s either in `~/.tmux/resurrect` or in `"${XDG_DATA_HOME:-$HOME/.local/share}"/tmux/resurrect`, wherever that is).
2. While your Tmux session is running, uninstall previous version of resurrect (remove plugin entry from Tmux conf & run TPM uninstall).
3. Install this version (add in Tmux conf & run TPM install, can use my fork repository while it’s not merged).
4. Save your session.
5. Check contents of the resurrect directory you located in step 1. Now they should contain a subdirectory `<tmux socket filename>`, which is `default` by default. Save and resurrect commands you run now act on current server (socket path) only.

Migrating back: generally, you can just revert to the old version, and whatever snapshot was in your resurrect directory should work again.

Thanks to @samm81.