### PR TITLE
Update restoring_bash_history.md

### DIFF
--- a/docs/restoring_bash_history.md
+++ b/docs/restoring_bash_history.md
@@ -35,5 +35,13 @@ else
 fi
 
 # Stash the new history each time a command runs.
-export PROMPT_COMMAND="$PROMPT_COMMAND;history -a"
+#export PROMPT_COMMAND="$PROMPT_COMMAND;history -a"
+if [[ -n "$PROMPT_COMMAND" ]]
+then
+  PROMPT_COMMAND=`echo $PROMPT_COMMAND|sed -e 's/;\s*$//g'`
+  export PROMPT_COMMAND="$PROMPT_COMMAND;history -a;"
+else
+  export PROMPT_COMMAND="history -a;"
+fi
+
 ```


### PR DESCRIPTION
In some terminal, when it startups, the PROMPT_COMMAND is empty (ERR: PROMPT_COMMAND=";history -a"),
and in some terminal else, the existance of trailing semicolon ; is uncertain. (ERR: PROMPT_COMMAND="xxxxxxxx;;history -a")