### PR TITLE
added login shell flag for zsh

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -109,7 +109,8 @@ tmux_socket() {
 cache_tmux_default_command() {
 	local default_shell="$(get_tmux_option "default-shell" "")"
 	local opt=""
-	if [ "$(basename "$default_shell")" == "bash" ]; then
+	local available_shells=(zsh bash)
+    if [[ " ${available_shells[*]} " =~ " $(basename "$default_shell") " ]]; then
 		opt="-l "
 	fi
 	export TMUX_DEFAULT_COMMAND="$(get_tmux_option "default-command" "$opt$default_shell")"


### PR DESCRIPTION
For zsh, tmux resurrect doesnt invoke login shells, added available shell array, future versions can add more shells to it that support the '-l' flag