### PR TITLE
Implement vifm session strategy

### DIFF
--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -9,7 +9,7 @@ restore_path_option="@resurrect-restore-script-path"
 
 # default processes that are restored
 default_proc_list_option="@resurrect-default-processes"
-default_proc_list='vi vim view nvim emacs man less more tail top htop irssi weechat mutt'
+default_proc_list='vi vim view nvim emacs man less more tail top htop irssi weechat mutt vifm'
 
 # User defined processes that are restored
 #  'false' - nothing is restored

--- a/strategies/vifm_session.sh
+++ b/strategies/vifm_session.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# "vifm session strategy"
+#
+# Restores a vifm session from the command line arguments.
+# vifm can be run from command line in particular session,
+# e.g. `vifm -c "session foo"`.
+# NOTE: the strategy doesn't work if a session is created/changed
+#       in vifm, e.g. `:session bar` vifm command
+
+ORIGINAL_COMMAND="$1"
+DIRECTORY="$2"
+
+main() {
+   local in_arg=0
+   local in_quote=0
+   local cmd=""
+   for word in $ORIGINAL_COMMAND; do
+      if [[ $word == -* ]]; then
+         if [[ $in_quote -eq 1 ]]; then
+            cmd+="\""
+            in_quote=0
+         fi
+         in_arg=1
+         cmd+=" $word"
+         continue;
+      fi
+
+      if [[ $in_arg -eq 0 ]]; then
+         cmd+=" $word"
+         continue
+      fi
+
+      if [[ $in_quote -eq 0 ]]; then
+         cmd+=" \"$word"
+         in_quote=1
+      else
+         cmd+=" $word"
+      fi
+
+   done
+
+   if [[ $in_quote -eq 1 ]]; then
+      cmd+="\""
+   fi
+
+   echo $cmd
+}
+main
+


### PR DESCRIPTION
Restores a vifm session from the command line arguments.

vifm can be run from command line in particular session, e.g. `vifm -c "session foo"`. The strategy parses the full command line arguments and sets quotes if they are needed.

NOTE: the strategy doesn't work if a session is created/changed in vifm, e.g. `:session bar` vifm command