### PR TITLE
Add confirm option for save and restore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You should now be able to use the plugin.
 **Configuration**
 
 - [Changing the default key bindings](docs/custom_key_bindings.md).
+- [Adding a confirmation step on save & restore](docs/confirm_actions.md).
 - [Setting up hooks on save & restore](docs/hooks.md).
 - Only a conservative list of programs is restored by default:<br/>
   `vi vim nvim emacs man less more tail top htop irssi weechat mutt`.<br/>

--- a/docs/confirm_actions.md
+++ b/docs/confirm_actions.md
@@ -1,0 +1,6 @@
+# Confirm save & restore actions
+
+By default save & restore will have no confirmation when the key bindings are pressed. To change this, add to `.tmux.conf`:
+
+    set -g @resurrect-save-confirm 'on'
+    set -g @resurrect-restore-confirm 'on'

--- a/docs/confirm_actions.md
+++ b/docs/confirm_actions.md
@@ -1,6 +1,6 @@
 # Confirm save & restore actions
 
-By default save & restore will have no confirmation when the key bindings are pressed. To change this, add to `.tmux.conf`:
+By default save & restore will have no confirmation step when the key bindings are pressed. To change this, add to `.tmux.conf`:
 
     set -g @resurrect-save-confirm 'on'
     set -g @resurrect-restore-confirm 'on'

--- a/resurrect.tmux
+++ b/resurrect.tmux
@@ -6,18 +6,34 @@ source "$CURRENT_DIR/scripts/variables.sh"
 source "$CURRENT_DIR/scripts/helpers.sh"
 
 set_save_bindings() {
+	local should_confirm_save=$(get_tmux_option "$confirm_save_option" "$default_confirm_save")
+	local command
+	if [ "$should_confirm_save" == "on" ]; then
+		command="confirm-before -y -p \"$confirm_save_prompt\" \"run-shell \\\"$CURRENT_DIR/scripts/save.sh\\\"\""
+	else
+		command="run-shell \"$CURRENT_DIR/scripts/save.sh\""
+	fi
+
 	local key_bindings=$(get_tmux_option "$save_option" "$default_save_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key "$key" run-shell "$CURRENT_DIR/scripts/save.sh"
+		tmux bind-key "$key" $command
 	done
 }
 
 set_restore_bindings() {
+	local should_confirm_restore=$(get_tmux_option "$confirm_restore_option" "$default_confirm_restore")
+	local command
+	if [ "$should_confirm_restore" == "on" ]; then
+		command="confirm-before -y -p \"$confirm_restore_prompt\" \"run-shell \\\"$CURRENT_DIR/scripts/restore.sh\\\"\""
+	else
+		command="run-shell \"$CURRENT_DIR/scripts/restore.sh\""
+	fi
+
 	local key_bindings=$(get_tmux_option "$restore_option" "$default_restore_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key "$key" run-shell "$CURRENT_DIR/scripts/restore.sh"
+		tmux bind-key "$key" $command
 	done
 }
 

--- a/resurrect.tmux
+++ b/resurrect.tmux
@@ -7,33 +7,37 @@ source "$CURRENT_DIR/scripts/helpers.sh"
 
 set_save_bindings() {
 	local should_confirm_save=$(get_tmux_option "$confirm_save_option" "$default_confirm_save")
+	local run_save_script="run-shell \"$CURRENT_DIR/scripts/save.sh\""
 	local command
 	if [ "$should_confirm_save" == "on" ]; then
-		command="confirm-before -y -p \"$confirm_save_prompt\" \"run-shell \\\"$CURRENT_DIR/scripts/save.sh\\\"\""
+		command="confirm-before -y -p \"$confirm_save_prompt\" \"$run_save_script\""
 	else
-		command="run-shell \"$CURRENT_DIR/scripts/save.sh\""
+		command="$run_save_script"
 	fi
 
 	local key_bindings=$(get_tmux_option "$save_option" "$default_save_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key "$key" $command
+		tmux unbind "$key"
+		tmux bind-key "$key" "$command"
 	done
 }
 
 set_restore_bindings() {
 	local should_confirm_restore=$(get_tmux_option "$confirm_restore_option" "$default_confirm_restore")
+	local run_restore_script="run-shell \"$CURRENT_DIR/scripts/restore.sh\""
 	local command
 	if [ "$should_confirm_restore" == "on" ]; then
-		command="confirm-before -y -p \"$confirm_restore_prompt\" \"run-shell \\\"$CURRENT_DIR/scripts/restore.sh\\\"\""
+		command="confirm-before -y -p \"$confirm_restore_prompt\" \"$run_restore_script\""
 	else
-		command="run-shell \"$CURRENT_DIR/scripts/restore.sh\""
+		command="$run_restore_script"
 	fi
 
 	local key_bindings=$(get_tmux_option "$restore_option" "$default_restore_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key "$key" $command
+		tmux unbind "$key"
+		tmux bind-key "$key" "$command"
 	done
 }
 

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -2,10 +2,16 @@
 default_save_key="C-s"
 save_option="@resurrect-save"
 save_path_option="@resurrect-save-script-path"
+default_confirm_save="off"
+confirm_save_option="@resurrect-confirm-save"
+confirm_save_prompt="Save tmux environment? (Y/n)"
 
 default_restore_key="C-r"
 restore_option="@resurrect-restore"
 restore_path_option="@resurrect-restore-script-path"
+default_confirm_restore="off"
+confirm_restore_option="@resurrect-confirm-restore"
+confirm_restore_prompt="Restore tmux environment? (Y/n)"
 
 # default processes that are restored
 default_proc_list_option="@resurrect-default-processes"


### PR DESCRIPTION
### Overview of PR
- Implemented support for optional `@resurrect-confirm-save` & `@resurrect-confirm-restore` options. These new options make use of `tmux`'s `confirm-before` command (see `man tmux`) to ask for confirmation before saving or restoring the `tmux` environment. 
- Updated docs to explain usage.
- Set default values to `off` so that current out-of-the-box plugin experience is not changed.

#### Motivation
I found myself accidentally saving & restoring my `tmux` environment because of their key binding similarity to other common actions I do (e.g. `<Prefix>+s` to list `tmux` sessions, `<Prefix>+r` to reload `.tmux.conf`), so I wanted to add a confirmation step to save & restore actions when using the `tmux-resurrect` plugin.

#### Screenshots
_Example `.tmux.conf` changes to use these new options_
![image](https://github.com/tmux-plugins/tmux-resurrect/assets/7005546/b03ce084-bab8-4731-9984-e2428bf01d45)

_Confirmation message for save action_
![image](https://github.com/tmux-plugins/tmux-resurrect/assets/7005546/26167e7f-10bb-4a96-9914-afc14810dc2b)

_Confirmation message for restore action_
![image](https://github.com/tmux-plugins/tmux-resurrect/assets/7005546/064bcac4-adcc-4c55-8a32-7518449483e4)
