### PR TITLE
docs/save_dir: Mention XDG_DATA_HOME

### DIFF
--- a/docs/save_dir.md
+++ b/docs/save_dir.md
@@ -1,6 +1,8 @@
 # Resurrect save dir
 
-By default Tmux environment is saved to a file in `~/.tmux/resurrect` dir.
+By default the Tmux environment is saved to a file in the `~/.tmux/resurrect`
+directory if it exists or `$XDG_DATA_HOME/tmux/resurrect` otherwise (which in
+turn falls back to `~/.local/share/tmux/resurrect` if `XDG_DATA_HOME` is unset).
 Change this with:
 
     set -g @resurrect-dir '/some/path'


### PR DESCRIPTION
After XDG_DATA_HOME/tmux/resurrect was introduced as a fallback for resurrect-dir, only docs/restoring_previously_saved_environment.md was updated.

Mention the new location also in the documentation about the save directory.