### PR TITLE
Folder is added for save_dir.md to align with restoring_previously_sa…

### DIFF
--- a/docs/save_dir.md
+++ b/docs/save_dir.md
@@ -1,6 +1,6 @@
 # Resurrect save dir
 
-By default Tmux environment is saved to a file in `~/.tmux/resurrect` dir.
+By default Tmux environment is saved to a file in `~/.tmux/resurrect` dir, or `~/.local/share/tmux/resurrect` dir.
 Change this with:
 
     set -g @resurrect-dir '/some/path'


### PR DESCRIPTION
The second folder that was mentioned in restoring_previously_saved_environment.md was missing in save_dir.md, so I added it to  be in sync.