### PR TITLE
Add missing hook to documentation

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -24,6 +24,11 @@ Currently the following hooks are supported:
 
   Called before running processes are restored.
 
+- `@resurrect-hook-post-restore-all`
+
+  Called at end of restore process right before the spinner is turned off.
+
+
 ### Examples
 
 Here is an example how to save and restore window geometry for most terminals in X11.


### PR DESCRIPTION
There was a `post-restore-all` hook not documented. This PR add this hook to /docs/hooks.md
