### PR TITLE
support `tmux split-pane` when restoring processes with `ps` strategy

### DIFF
--- a/save_command_strategies/ps.sh
+++ b/save_command_strategies/ps.sh
@@ -11,10 +11,18 @@ exit_safely_if_empty_ppid() {
 }
 
 full_command() {
-	ps -ao "ppid,args" |
+	# normally the PID is a shell. return the child that has an associated controlling terminal.
+	child=$(ps -ao "ppid,args" |
 		sed "s/^ *//" |
 		grep "^${PANE_PID}" |
-		cut -d' ' -f2-
+		cut -d' ' -f2-)
+	if [ "$child" ]; then
+		printf %s "$child"
+		return
+	fi
+	# if this command was spawned with `tmux split-pane`, it has no parent shell.
+	# just return the args for the PID itself.
+	ps -p "${PANE_PID}" -o args | tail -n +2
 }
 
 main() {


### PR DESCRIPTION
normally, `ps.sh` takes the output of `tmux list-panes -F "#{pane_pid}"` and looks for all the children of that process with a controlling terminal, because that process is usually a shell. but if the process in a pane was spawned with `tmux split-pane`, it will have no parent process other than the tmux server itself.

support this use case by falling back to the active process if the active process has no children with a controlling terminal.

fixes https://github.com/tmux-plugins/tmux-resurrect/issues/517