### PR TITLE
helpers/pane_contents_file: Avoid path issues by trimming "/" characters

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -128,6 +128,8 @@ pane_contents_dir() {
 pane_contents_file() {
 	local save_or_restore="$1"
 	local pane_id="$2"
+	# avoid path issues if pane_id has "/" characters
+	pane_id=${pane_id//\//_}
 	echo "$(pane_contents_dir "$save_or_restore")/pane-${pane_id}"
 }
 


### PR DESCRIPTION
Currently, if a session has "/" in its name the save.sh script will fail.