### PR TITLE
Skip restore content cleanup to fix fish shell restore

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -89,6 +89,7 @@ pane_content_files_restore_from_archive() {
 	local archive_file="$(pane_contents_archive_file)"
 	if [ -f "$archive_file" ]; then
 		mkdir -p "$(pane_contents_dir "restore")"
+		rm "$(pane_contents_dir "restore")"/* # Clean up any existing files
 		gzip -d < "$archive_file" |
 			tar xf - -C "$(resurrect_dir)/restore/"
 	fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -355,14 +355,6 @@ restore_active_and_alternate_sessions() {
 	done < $(last_resurrect_file)
 }
 
-# A cleanup that happens after 'restore_all_panes' seems to fix fish shell
-# users' restore problems.
-cleanup_restored_pane_contents() {
-	if is_restoring_pane_contents; then
-		rm "$(pane_contents_dir "restore")"/*
-	fi
-}
-
 main() {
 	if supported_tmux_version_ok && check_saved_session_exists; then
 		start_spinner "Restoring..." "Tmux restore complete!"
@@ -378,7 +370,6 @@ main() {
 		restore_grouped_sessions  # also restores active and alt windows for grouped sessions
 		restore_active_and_alternate_windows
 		restore_active_and_alternate_sessions
-		cleanup_restored_pane_contents
 		execute_hook "post-restore-all"
 		stop_spinner
 		display_message "Tmux restore complete!"


### PR DESCRIPTION
Fixes #526

When using fish shell, it seems all windows except the first one for each session will error when restoring pane contents. The error is something along the lines of `cat: '/home/monarch/.local/share/tmux/resurrect/restore/pane_contents//pane-0:1.0': No such file or directory` (from #526).

My best guess is that fish lazily runs commands or something and each window after the first in tmux doesn't trigger this until opened later.

Either way, instead of cleaning up the pane content files after we've attempted the restore, I leave the files around until the _next_ restore, where I delete them just before we untar the saved contents. This way, the files hang around long enough for the panes to restore them (lazily?), but we still make sure they're reset before the next restore (cleaning up any extra files from the previous restore that may not be in the new one).
