### PR TITLE
add support to changed special character handling

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -100,7 +100,7 @@ resurrect_dir() {
 	if [ -z "$_RESURRECT_DIR" ]; then
 		local path="$(get_tmux_option "$resurrect_dir_option" "$default_resurrect_dir")"
 		# expands tilde, $HOME and $HOSTNAME if used in @resurrect-dir
-		echo "$path" | sed "s,\$HOME,$HOME,g; s,\$HOSTNAME,$(hostname),g; s,\~,$HOME,g"
+		echo "$path" | sed "s,\\\\\$HOME,$HOME,g; s,\\\\\$HOSTNAME,$(hostname),g; s,\$HOME,$HOME,g; s,\$HOSTNAME,$(hostname),g; s,\~,$HOME,g"
 	else
 		echo "$_RESURRECT_DIR"
 	fi


### PR DESCRIPTION
Newer versions of tmux (observed on 3.4, on Ubuntu 24.04) in comparison to the older one (observed on 3.2a, on Ubuntu 22.04) changed behavior in how special characters within the option values are returned by the command `tmux show-option -gqv`. Now, it adds a leading backslash to each special character.

On Ubuntu 22.04 with tmux 3.2a:

```sh
$ tmux -V
tmux 3.2a
$ tmux show-option -gqv '@resurrect-dir'
~/.tmux/resurrect/$HOSTNAME
```

On Ubuntu 24.04 with tmux 3.4:

```sh
$ tmux -V
tmux 3.4
$ tmux show-option -gqv '@resurrect-dir'
~/.tmux/resurrect/\$HOSTNAME
```

This breaks the expansion of environment variables that is done by the function `resurrect_dir()` (in #/scripts/helpers.sh). 

This commit adds support for this new representation of special characters, in addition to the older ones.