### PR TITLE
Add feature to restore paste buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Optional:
 
 - [restoring vim and neovim sessions](docs/restoring_vim_and_neovim_sessions.md)
 - [restoring pane contents](docs/restoring_pane_contents.md)
+- [restoring paste buffers](docs/restoring_paste_buffers.md)
 - [restoring a previously saved environment](docs/restoring_previously_saved_environment.md)
 
 Requirements / dependencies: `tmux 1.9` or higher, `bash`.

--- a/docs/restoring_paste_buffers.md
+++ b/docs/restoring_paste_buffers.md
@@ -1,0 +1,7 @@
+# Restoring paste buffers
+
+This feature saves and restores tmux paste buffers.
+
+It can be enabled by adding this line to `.tmux.conf`:
+
+    set -g @resurrect-paste-buffers 'on'

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -38,6 +38,9 @@ pane_contents_option="@resurrect-capture-pane-contents"
 pane_contents_area_option="@resurrect-pane-contents-area"
 default_pane_contents_area="full"
 
+# Paste buffer restore options
+paste_buffers_option="@resurrect-paste-buffers"
+
 # set to 'on' to ensure panes are never ever overwritten
 overwrite_option="@resurrect-never-overwrite"
 


### PR DESCRIPTION
It is disabled by default and enabled using @resurrect-paste-buffers.

Paste buffers are listed and dumped in a tar.gz at save time, similar to what is done for pane contents. At restore time, the archive is extracted and paste buffers are restored in order.