### PR TITLE
chore: remove dangling symlink files that points to nothing.

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,1 +1,0 @@
-lib/tmux-test/run_tests

--- a/tests/helpers/helpers.sh
+++ b/tests/helpers/helpers.sh
@@ -1,1 +1,0 @@
-../../lib/tmux-test/tests/helpers/helpers.sh

--- a/tests/run_tests_in_isolation
+++ b/tests/run_tests_in_isolation
@@ -1,1 +1,0 @@
-../lib/tmux-test/tests/run_tests_in_isolation


### PR DESCRIPTION
this pull request removes the `run_tests`, `tests/helpers/helpers.sh`, `tests/run_tests_in_isolation` files that exists for 10 years and these files are actually symlinks that points to nothing so why not remove it?

![Screenshot_20250130-135539](https://github.com/user-attachments/assets/aabe67c9-3b98-4ff0-b977-88cf54593bfb)
