### PR TITLE
feature: add support for folke/persistence.nvim plugin

### DIFF
--- a/strategies/nvim_session.sh
+++ b/strategies/nvim_session.sh
@@ -15,6 +15,12 @@ original_command_contains_session_flag() {
 	[[ "$ORIGINAL_COMMAND" =~ "-S" ]]
 }
 
+persistence_nvim_plugin_exists() {
+	nvim --headless -c 'lua if not pcall(require, "persistence") then os.exit(1) end' -c 'qa'
+	# shellcheck disable=2181
+	[ $? -eq 0 ]
+}
+
 main() {
 	if nvim_session_file_exists; then
 		echo "nvim -S"
@@ -23,6 +29,10 @@ main() {
 		# session flag `-S`. This will cause an error, so we're falling back to
 		# starting plain nvim.
 		echo "nvim"
+	elif persistence_nvim_plugin_exists; then
+		# Load folke's persistence.nvim sessions. And Shoutout to ThePrimeagen and TjDevries.
+		# Also Shoutout to my favorite youtuber Mr. Hussein Nasser because I'm learning a lot from you.
+		echo "nvim -c 'lua require(\"persistence\").load()'"
 	else
 		echo "$ORIGINAL_COMMAND"
 	fi


### PR DESCRIPTION
This PR add support for `folke/persistence.nvim` as an alternative for `tpope/vim-obsession` for neovim.

As a neovim user myself, I love **folke**'s work and only want **folke**'s plugins when possible.

And for people who loves or use `tpope/vim-obsession` and can't get it to work with `tmux-ressurect` just add this on your config.

```lua
return {
	'tpope/vim-obsession',
	enabled = true,
	event = 'VimEnter',
	init = function()
		vim.api.nvim_create_autocmd('VimLeave', {
			pattern = '*',
			group = vim.api.nvim_create_augroup('Obsession', { clear = true }),
			callback = function() vim.cmd 'Obsession' end,
		})
	end,
}
```
This config that I pasted will only work if you are using `folke/lazy.nvim` as your plugin manager, and if not I don't know what to tell you but may god have mercy on you.

Closes #470