### PR TITLE
Update symlink only after the content archive is ready.

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -81,8 +81,13 @@ is_session_grouped() {
 # pane content file helpers
 
 pane_contents_create_archive() {
+	local archive_file="$(pane_contents_archive_file)"
+	if [ -f "$archive_file" ]; then
+		mv "$archive_file" "$archive_file"-old
+	fi
 	tar cf - -C "$(resurrect_dir)/save/" ./pane_contents/ |
-		gzip > "$(pane_contents_archive_file)"
+		gzip > "$archive_file"
+	rm "$archive_file"-old
 }
 
 pane_content_files_restore_from_archive() {

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -244,16 +244,16 @@ save_all() {
 	dump_windows >> "$resurrect_file_path"
 	dump_state   >> "$resurrect_file_path"
 	execute_hook "post-save-layout" "$resurrect_file_path"
-	if files_differ "$resurrect_file_path" "$last_resurrect_file"; then
-		ln -fs "$(basename "$resurrect_file_path")" "$last_resurrect_file"
-	else
-		rm "$resurrect_file_path"
-	fi
 	if capture_pane_contents_option_on; then
 		mkdir -p "$(pane_contents_dir "save")"
 		dump_pane_contents
 		pane_contents_create_archive
 		rm "$(pane_contents_dir "save")"/*
+	fi
+	if files_differ "$resurrect_file_path" "$last_resurrect_file"; then
+		ln -fs "$(basename "$resurrect_file_path")" "$last_resurrect_file"
+	else
+		rm "$resurrect_file_path"
 	fi
 	remove_old_backups
 	execute_hook "post-save-all"


### PR DESCRIPTION
Otherwise, if the computer shuts down while the archive is being created, then the symlink will point to a file possibly incompatible with the archive.