### PR TITLE
Add per-session save files/session manager script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Automatic restoring and continuous saving of tmux env is also possible with
 - `prefix + Ctrl-s` - save
 - `prefix + Ctrl-r` - restore
 
+**Custom key bindings example:**
+
+If you prefer simpler key bindings (e.g., `prefix + s` instead of `prefix + Ctrl-s`),
+add this to your `.tmux.conf`:
+
+    # Save session with prefix + s
+    bind-key s run-shell '~/.tmux/plugins/tmux-resurrect/scripts/save.sh'
+
+    # Restore session with prefix + R
+    bind-key R run-shell '~/.tmux/plugins/tmux-resurrect/scripts/restore.sh'
+
 ### About
 
 This plugin goes to great lengths to save and restore all the details from your
@@ -82,6 +93,23 @@ Add this line to the bottom of `.tmux.conf`:
 
 Reload TMUX environment with: `$ tmux source-file ~/.tmux.conf`.
 You should now be able to use the plugin.
+
+### Session Manager (`attach` command)
+
+Upon installation, tmux-resurrect creates an `attach` script in `$HOME/bin/`
+that provides an interactive session manager. Simply run `attach` in your
+terminal to:
+
+- List all saved tmux sessions
+- Restore a session by selecting its number
+- Delete saved sessions (press `d`)
+- Rename saved sessions (press `r`)
+
+**Note:** For the `attach` command to work, `$HOME/bin` must be in your PATH.
+Most Linux distributions include this by default, but if not, add this to your
+`.bashrc` or `.zshrc`:
+
+    export PATH="$HOME/bin:$PATH"
 
 ### Docs
 

--- a/resurrect.tmux
+++ b/resurrect.tmux
@@ -31,10 +31,161 @@ set_script_path_options() {
 	tmux set-option -gq "$restore_path_option" "$CURRENT_DIR/scripts/restore.sh"
 }
 
+install_attach_script() {
+	local bin_dir="$HOME/bin"
+	local attach_script="$bin_dir/attach"
+
+	# Only create if attach script doesn't already exist
+	if [[ -f "$attach_script" ]]; then
+		return 0
+	fi
+
+	# Create $HOME/bin if it doesn't exist
+	mkdir -p "$bin_dir"
+
+	# Create the attach script
+	cat > "$attach_script" << ATTACH_SCRIPT
+#!/bin/bash
+
+# Directory where tmux-resurrect saves sessions
+RESURRECT_DIR="\$HOME/.tmux/resurrect"
+
+# Path to restore script (set at install time)
+RESTORE_SCRIPT="$CURRENT_DIR/scripts/restore.sh"
+
+# Check if the directory exists
+if [[ ! -d "\$RESURRECT_DIR" ]]; then
+    echo "Error: Tmux-resurrect directory not found at \$RESURRECT_DIR"
+    exit 1
+fi
+
+# List saved sessions
+echo "Available saved tmux sessions:"
+SAVED_SESSIONS=(\$(find "\$RESURRECT_DIR" -maxdepth 1 -type f ! -name "last" ! -name "readme*" -printf "%f\n" | sort))
+if [[ \${#SAVED_SESSIONS[@]} -eq 0 ]]; then
+    echo "No saved sessions found."
+    exit 0
+fi
+
+# Display session names
+for i in "\${!SAVED_SESSIONS[@]}"; do
+    echo "\$i) \${SAVED_SESSIONS[\$i]}"
+done
+
+echo ""
+echo "Options: [number] to restore, [d/D] to delete, [r/R] to rename"
+read -p "Enter your choice: " CHOICE
+
+# Handle delete option
+if [[ "\$CHOICE" =~ ^[dD]\$ ]]; then
+    read -p "Enter the number of the session to delete: " DEL_CHOICE
+    if [[ ! "\$DEL_CHOICE" =~ ^[0-9]+\$ ]] || [[ "\$DEL_CHOICE" -ge "\${#SAVED_SESSIONS[@]}" ]]; then
+        echo "Invalid selection. Exiting."
+        exit 1
+    fi
+    DEL_SESSION="\${SAVED_SESSIONS[\$DEL_CHOICE]}"
+    read -p "Are you sure you want to delete '\$DEL_SESSION'? [y/N]: " CONFIRM
+    if [[ "\$CONFIRM" =~ ^[yY]\$ ]]; then
+        rm "\$RESURRECT_DIR/\$DEL_SESSION"
+        echo "Deleted: \$DEL_SESSION"
+    else
+        echo "Deletion cancelled."
+    fi
+    exit 0
+fi
+
+# Handle rename option
+if [[ "\$CHOICE" =~ ^[rR]\$ ]]; then
+    read -p "Enter the number of the session to rename: " REN_CHOICE
+    if [[ ! "\$REN_CHOICE" =~ ^[0-9]+\$ ]] || [[ "\$REN_CHOICE" -ge "\${#SAVED_SESSIONS[@]}" ]]; then
+        echo "Invalid selection. Exiting."
+        exit 1
+    fi
+    OLD_SESSION="\${SAVED_SESSIONS[\$REN_CHOICE]}"
+    read -p "Enter new name (without .txt extension): " NEW_NAME
+    if [[ -z "\$NEW_NAME" ]]; then
+        echo "Invalid name. Exiting."
+        exit 1
+    fi
+    NEW_SESSION="\${NEW_NAME}.txt"
+    if [[ -f "\$RESURRECT_DIR/\$NEW_SESSION" ]]; then
+        echo "Error: A session with that name already exists."
+        exit 1
+    fi
+    mv "\$RESURRECT_DIR/\$OLD_SESSION" "\$RESURRECT_DIR/\$NEW_SESSION"
+    echo "Renamed: \$OLD_SESSION -> \$NEW_SESSION"
+    exit 0
+fi
+
+# Handle restore (number input)
+if [[ ! "\$CHOICE" =~ ^[0-9]+\$ ]] || [[ "\$CHOICE" -ge "\${#SAVED_SESSIONS[@]}" ]]; then
+    echo "Invalid selection. Exiting."
+    exit 1
+fi
+
+# Restore the selected session
+SELECTED_SESSION="\${SAVED_SESSIONS[\$CHOICE]}"
+
+# Extract the desired session name (remove .txt extension)
+DESIRED_NAME="\${SELECTED_SESSION%.txt}"
+
+# Check if 'last' is a symlink and remove it if necessary
+if [[ -L "\$RESURRECT_DIR/last" ]]; then
+    rm "\$RESURRECT_DIR/last"
+fi
+
+# Copy the selected session to 'last'
+cp "\$RESURRECT_DIR/\$SELECTED_SESSION" "\$RESURRECT_DIR/last"
+
+# Ensure the tmux server is running by creating a detached session
+temp_session="resurrect-temp-\$\$-\$RANDOM"
+created_temp_session=false
+if tmux new-session -d -s "\$temp_session" 2>/dev/null; then
+    created_temp_session=true
+fi
+
+# Restore the session using tmux-resurrect
+tmux run-shell "\$RESTORE_SCRIPT"
+
+# Wait for restoration to complete
+sleep 2
+
+# Kill the temp session only if we created it
+if [[ "\$created_temp_session" == true ]]; then
+    tmux kill-session -t "\$temp_session" 2>/dev/null
+fi
+
+# Get all sessions
+SESSIONS=\$(tmux list-sessions -F '#{session_name}' 2>/dev/null)
+
+if [[ -z "\$SESSIONS" ]]; then
+    echo "Error: No sessions found after restoration."
+    exit 1
+fi
+
+# Get the first session (the restored one)
+FIRST_SESSION=\$(echo "\$SESSIONS" | head -n 1)
+
+# Rename the session to match the filename
+tmux rename-session -t "\$FIRST_SESSION" "\$DESIRED_NAME"
+
+echo "Available sessions after restoration:"
+tmux list-sessions
+
+echo ""
+echo "Attaching to session: \$DESIRED_NAME"
+tmux attach-session -t "\$DESIRED_NAME"
+ATTACH_SCRIPT
+
+	# Make it executable
+	chmod +x "$attach_script"
+}
+
 main() {
 	set_save_bindings
 	set_restore_bindings
 	set_default_strategies
 	set_script_path_options
+	install_attach_script
 }
 main

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -109,8 +109,17 @@ _RESURRECT_DIR="$(resurrect_dir)"
 
 resurrect_file_path() {
 	if [ -z "$_RESURRECT_FILE_PATH" ]; then
-		local timestamp="$(date +"%Y%m%dT%H%M%S")"
-		echo "$(resurrect_dir)/${RESURRECT_FILE_PREFIX}_${timestamp}.${RESURRECT_FILE_EXTENSION}"
+		local current_session="$(tmux display-message -p '#S')"
+
+		# Check if session name is just a number (default unnamed session)
+		if [[ "$current_session" =~ ^[0-9]+$ ]]; then
+			# Prompt for a session name
+			tmux command-prompt -p "Save session as:" "run-shell 'tmux rename-session %1'"
+			# Get the new session name after renaming
+			current_session="$(tmux display-message -p '#S')"
+		fi
+
+		echo "$(resurrect_dir)/${current_session}.${RESURRECT_FILE_EXTENSION}"
 	else
 		echo "$_RESURRECT_FILE_PATH"
 	fi

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -244,11 +244,7 @@ save_all() {
 	dump_windows >> "$resurrect_file_path"
 	dump_state   >> "$resurrect_file_path"
 	execute_hook "post-save-layout" "$resurrect_file_path"
-	if files_differ "$resurrect_file_path" "$last_resurrect_file"; then
-		ln -fs "$(basename "$resurrect_file_path")" "$last_resurrect_file"
-	else
-		rm "$resurrect_file_path"
-	fi
+	ln -fs "$(basename "$resurrect_file_path")" "$last_resurrect_file"
 	if capture_pane_contents_option_on; then
 		mkdir -p "$(pane_contents_dir "save")"
 		dump_pane_contents


### PR DESCRIPTION
  - Modified resurrect_file_path() to save sessions using session name
  - Prompts user to name session if using default numeric name
  - Added session manager script to $HOME/bin/ on install
    - Interactive menu to attach, delete, or rename saved sessions
  - Allows multiple distinct session saves instead of single global file

What the change does                                                                                                                                                                        
                                                                                                                                                                                              
  This modification enhances tmux-resurrect to save session state on a per-session basis rather than using a single global save file. Additionally, it includes a session manager script that 
  provides an interactive menu for managing saved sessions.                                                                                                                                   
                                                                                                                                                                                              
  Core changes:                                                                                                                                                                               
  - Modifies resurrect_file_path() to use the tmux session name as the save filename (e.g., ~/.tmux/resurrect/dev-project.txt instead of last)                                                
  - Prompts the user to name their session if it still has the default numeric name (e.g., 0, 1)                                                                                              
  - Installs a tmux-session-manager script to $HOME/bin/ that allows users to:                                                                                                                
    - Attach to a previously saved session                                                                                                                                                    
    - Delete saved session files                                                                                                                                                              
    - Rename saved sessions                                                                                                                                                                   
                                                                                                                                                                                              
  Why it's useful                                                                                                                                                                             
                                                                                                                                                                                              
  - Multiple project workflows: Keep separate save states for different projects without overwriting each other                                                                               
  - Cleaner organization: Session saves are named meaningfully instead of using timestamps                                                                                                    
  - Easy management: The session manager script provides a simple way to browse, clean up, or reorganize saved sessions without manually navigating the resurrect directory                   
  - Safer restores: Restoring one session won't accidentally load state from a completely different project                                                                                   
                                                                                                                                                                                              
  Breaking changes                                                                                                                                                                            
                                                                                                                                                                                              
  - Save file location changed: Existing saves in ~/.tmux/resurrect/last will not be automatically migrated. Users should manually restore their old session once, then save it under the new 
  naming scheme.                                                                                                                                                                              
  - Session naming prompt: Users with default-named sessions will now be prompted to provide a name on first save. This can be skipped by pre-naming sessions with tmux rename-session.