### PR TITLE
Save and restore pane titles, border status, and border format labels

### DIFF
--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -363,6 +363,21 @@ cleanup_restored_pane_contents() {
 	fi
 }
 
+# Re-apply pane titles after all pane processes have been restored.
+# Shells (bash, zsh, etc.) typically set the pane title via escape sequences
+# in PROMPT_COMMAND/PS1, which overwrites the title set during pane creation
+# in restore_pane(). Running this step after process restoration ensures
+# custom pane titles (e.g. "hermes-exec-pane", "hermes-dialog-pane")
+# survive the shell restart.
+restore_pane_titles() {
+	awk 'BEGIN { FS="	"; OFS="	" } /^pane/ { print $2, $3, $6, $7; }' "$(last_resurrect_file)" |
+		while IFS=$d read -r session_name window_number pane_index pane_title; do
+			if pane_exists "$session_name" "$window_number" "$pane_index"; then
+				tmux select-pane -t "${session_name}:${window_number}.${pane_index}" -T "$pane_title"
+			fi
+		done
+}
+
 main() {
 	if supported_tmux_version_ok && check_saved_session_exists; then
 		start_spinner "Restoring..." "Tmux restore complete!"
@@ -375,6 +390,10 @@ main() {
 		# below functions restore exact cursor positions
 		restore_active_pane_for_each_window
 		restore_zoomed_windows
+		# restore pane titles after process restoration — shells (bash/zsh)
+		# set the title via escape sequences, which would overwrite the title
+		# set during pane creation otherwise
+		restore_pane_titles
 		restore_grouped_sessions  # also restores active and alt windows for grouped sessions
 		restore_active_and_alternate_windows
 		restore_active_and_alternate_sessions

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -287,7 +287,7 @@ handle_session_0() {
 restore_window_properties() {
 	local window_name
 	\grep '^window' $(last_resurrect_file) |
-		while IFS=$d read line_type session_name window_number window_name window_active window_flags window_layout automatic_rename; do
+		while IFS=$d read line_type session_name window_number window_name window_active window_flags window_layout automatic_rename border_status border_format; do
 			tmux select-layout -t "${session_name}:${window_number}" "$window_layout"
 
 			# Below steps are properly handling window names and automatic-rename
@@ -299,6 +299,13 @@ restore_window_properties() {
 				tmux set-option -u -t "${session_name}:${window_number}" automatic-rename
 			else
 				tmux set-option -t "${session_name}:${window_number}" automatic-rename "$automatic_rename"
+			fi
+			# Restore window-level pane-border-status and pane-border-format
+			if [ -n "$border_status" ] && [ "$border_status" != ":" ]; then
+				tmux set-option -w -t "${session_name}:${window_number}" pane-border-status "$border_status"
+			fi
+			if [ -n "$border_format" ] && [ "$border_format" != ":" ]; then
+				tmux set-option -w -t "${session_name}:${window_number}" pane-border-format "$border_format"
 			fi
 		done
 }
@@ -378,6 +385,23 @@ restore_pane_titles() {
 		done
 }
 
+# Read saved pane_border lines and re-apply per-pane border options
+# (pane-border-status and pane-border-format) via tmux set -p.
+restore_pane_borders() {
+	awk 'BEGIN { FS="	"; OFS="	" } /^pane_border/ { print $2, $3, $4, $5, $6; }' "$(last_resurrect_file)" |
+		while IFS=$d read -r session_name window_number pane_index status format; do
+			local target="${session_name}:${window_number}.${pane_index}"
+			if pane_exists "$session_name" "$window_number" "$pane_index"; then
+				if [ -n "$status" ]; then
+					tmux set -p -t "$target" pane-border-status "$status"
+				fi
+				if [ -n "$format" ]; then
+					tmux set -p -t "$target" pane-border-format "$format"
+				fi
+			fi
+		done
+}
+
 main() {
 	if supported_tmux_version_ok && check_saved_session_exists; then
 		start_spinner "Restoring..." "Tmux restore complete!"
@@ -394,6 +418,8 @@ main() {
 		# set the title via escape sequences, which would overwrite the title
 		# set during pane creation otherwise
 		restore_pane_titles
+		# restore pane borders (status and format label)
+		restore_pane_borders
 		restore_grouped_sessions  # also restores active and alt windows for grouped sessions
 		restore_active_and_alternate_windows
 		restore_active_and_alternate_sessions

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -376,11 +376,23 @@ cleanup_restored_pane_contents() {
 # in restore_pane(). Running this step after process restoration ensures
 # custom pane titles (e.g. "hermes-exec-pane", "hermes-dialog-pane")
 # survive the shell restart.
+#
+# To avoid restoring stale dynamic titles (e.g. "user@host: /old/path") on
+# panes that rely on the shell to set their title, we only restore titles
+# for panes that have a custom pane-border override (pane_border lines).
+# This links title restoration to the presence of a deliberate visual
+# customization.
 restore_pane_titles() {
+	local border_panes=""
+	border_panes="$(awk 'BEGIN { FS="	" } /^pane_border/ { print $2":"$3"."$4 }' "$(last_resurrect_file)")"
 	awk 'BEGIN { FS="	"; OFS="	" } /^pane/ { print $2, $3, $6, $7; }' "$(last_resurrect_file)" |
 		while IFS=$d read -r session_name window_number pane_index pane_title; do
-			if pane_exists "$session_name" "$window_number" "$pane_index"; then
-				tmux select-pane -t "${session_name}:${window_number}.${pane_index}" -T "$pane_title"
+			local key="${session_name}:${window_number}.${pane_index}"
+			# only restore title for panes with custom border overrides
+			if echo "$border_panes" | grep -qxF "$key"; then
+				if pane_exists "$session_name" "$window_number" "$pane_index"; then
+					tmux select-pane -t "${session_name}:${window_number}.${pane_index}" -T "$pane_title"
+				fi
 			fi
 		done
 }

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -385,13 +385,21 @@ cleanup_restored_pane_contents() {
 restore_pane_titles() {
 	local border_panes=""
 	border_panes="$(awk 'BEGIN { FS="	" } /^pane_border/ { print $2":"$3"."$4 }' "$(last_resurrect_file)")"
-	awk 'BEGIN { FS="	"; OFS="	" } /^pane/ { print $2, $3, $6, $7; }' "$(last_resurrect_file)" |
+	# NOTE: /^pane	/ avoids matching "pane_border" lines
+	awk 'BEGIN { FS="	"; OFS="	" } /^pane	/ { print $2, $3, $6, $7; }' "$(last_resurrect_file)" |
 		while IFS=$d read -r session_name window_number pane_index pane_title; do
 			local key="${session_name}:${window_number}.${pane_index}"
 			# only restore title for panes with custom border overrides
 			if echo "$border_panes" | grep -qxF "$key"; then
 				if pane_exists "$session_name" "$window_number" "$pane_index"; then
+					# select-pane -T changes the active pane, which would
+					# undo restore_active_pane_for_each_window. Save and
+					# restore the active pane around the title set.
+					local previous_active="$(tmux display -t "${session_name}:${window_number}" -p '#{pane_id}' 2>/dev/null)"
 					tmux select-pane -t "${session_name}:${window_number}.${pane_index}" -T "$pane_title"
+					if [ -n "$previous_active" ]; then
+						tmux select-pane -t "$previous_active" 2>/dev/null
+					fi
 				fi
 			fi
 		done

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -24,7 +24,7 @@ is_line_type() {
 	local line_type="$1"
 	local line="$2"
 	echo "$line" |
-		\grep -q "^$line_type"
+		\grep -q "^${line_type}"$'	'
 }
 
 check_saved_session_exists() {

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -210,7 +210,13 @@ dump_windows() {
 			automatic_rename="$(tmux show-window-options -vt "${session_name}:${window_index}" automatic-rename)"
 			# If the option was unset, use ":" as a placeholder.
 			[ -z "${automatic_rename}" ] && automatic_rename=":"
-			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_name}${d}${window_active}${d}${window_flags}${d}${window_layout}${d}${automatic_rename}"
+			# Capture window-level pane-border-status and pane-border-format
+			local win_target="${session_name}:${window_index}"
+			local border_status="$(tmux show-options -w -t "$win_target" pane-border-status 2>/dev/null | sed 's/^pane-border-status //')"
+			local border_format="$(tmux show-options -w -t "$win_target" pane-border-format 2>/dev/null | sed 's/^pane-border-format //' | sed 's/^"//;s/"$//')"
+			[ -z "$border_status" ] && border_status=":"
+			[ -z "$border_format" ] && border_format=":"
+			echo "${line_type}${d}${session_name}${d}${window_index}${d}${window_name}${d}${window_active}${d}${window_flags}${d}${window_layout}${d}${automatic_rename}${d}${border_status}${d}${border_format}"
 		done
 }
 
@@ -223,6 +229,64 @@ dump_pane_contents() {
 	dump_panes_raw |
 		while IFS=$d read line_type session_name window_number window_active window_flags pane_index pane_title dir pane_active pane_command pane_pid history_size; do
 			capture_pane_contents "${session_name}:${window_number}.${pane_index}" "$history_size" "$pane_contents_area"
+		done
+}
+
+# Dump per-pane pane-border-status and pane-border-format overrides.
+# These are window options set per-pane via `set -p`, and tmux format
+# variables #{pane_border_status} / #{pane_border_format} are not available
+# in list-panes -F output (tmux 3.4), so we query them via show-options -p.
+# Only panes with values different from their window-level setting are
+# emitted (actual overrides, not inherited values).
+dump_pane_borders() {
+	dump_panes_raw |
+		while IFS=$d read line_type session_name window_number window_active window_flags pane_index pane_title dir pane_active pane_command pane_pid history_size; do
+			if is_session_grouped "$session_name"; then
+				continue
+			fi
+			local target="${session_name}:${window_number}.${pane_index}"
+			local win_target="${session_name}:${window_number}"
+
+			# Get pane-scope effective values
+			local pane_status=""
+			local raw_pane_status="$(tmux show-options -p -t "$target" pane-border-status 2>/dev/null)"
+			[ -n "$raw_pane_status" ] && pane_status="${raw_pane_status#pane-border-status }"
+
+			local pane_format=""
+			local raw_pane_format="$(tmux show-options -p -t "$target" pane-border-format 2>/dev/null)"
+			if [ -n "$raw_pane_format" ]; then
+				pane_format="${raw_pane_format#pane-border-format }"
+				pane_format="${pane_format#\"}"
+				pane_format="${pane_format%\"}"
+			fi
+
+			# Get window-scope values for comparison
+			local win_status=""
+			local raw_win_status="$(tmux show-options -w -t "$win_target" pane-border-status 2>/dev/null)"
+			[ -n "$raw_win_status" ] && win_status="${raw_win_status#pane-border-status }"
+
+			local win_format=""
+			local raw_win_format="$(tmux show-options -w -t "$win_target" pane-border-format 2>/dev/null)"
+			if [ -n "$raw_win_format" ]; then
+				win_format="${raw_win_format#pane-border-format }"
+				win_format="${win_format#\"}"
+				win_format="${win_format%\"}"
+			fi
+
+			# Only save if pane value differs from window value (actual override)
+			local needs_status=0
+			local needs_format=0
+			[ -n "$pane_status" ] && [ "$pane_status" != "$win_status" ] && needs_status=1
+			[ -n "$pane_format" ] && [ "$pane_format" != "$win_format" ] && needs_format=1
+
+			if [ $needs_status -eq 1 ] || [ $needs_format -eq 1 ]; then
+				# Only include values that are actual overrides
+				local out_status=""
+				[ $needs_status -eq 1 ] && out_status="$pane_status"
+				local out_format=""
+				[ $needs_format -eq 1 ] && out_format="$pane_format"
+				echo "pane_border${d}${session_name}${d}${window_number}${d}${pane_index}${d}${out_status}${d}${out_format}"
+			fi
 		done
 }
 
@@ -242,6 +306,7 @@ save_all() {
 	fetch_and_dump_grouped_sessions > "$resurrect_file_path"
 	dump_panes   >> "$resurrect_file_path"
 	dump_windows >> "$resurrect_file_path"
+	dump_pane_borders >> "$resurrect_file_path"
 	dump_state   >> "$resurrect_file_path"
 	execute_hook "post-save-layout" "$resurrect_file_path"
 	if files_differ "$resurrect_file_path" "$last_resurrect_file"; then


### PR DESCRIPTION
## Summary

Extends tmux-resurrect to preserve pane titles and pane border visual state (border status and border format labels) across save/restore cycles. This ensures that custom pane titles like `hermes-exec-pane`/`hermes-dialog-pane` and border labels like `󰭻 Hermes 对话`/` 执行终端` set by tools like `tmux-dual-pane` survive a full restore.

## Changes

### 1. Re-apply pane titles after process restoration

The existing `restore_pane()` already sets `pane_title` via `select-pane -T` during pane creation, but shells (bash, zsh) overwrite it via PROMPT_COMMAND escape sequences once they start. A new `restore_pane_titles()` step re-applies saved pane titles **after** `restore_all_pane_processes()` so custom titles survive the shell restart.

To avoid restoring stale dynamic titles (e.g. `user@host: /old/path`) on panes that rely on the shell to set their title, title restoration is linked to the presence of a deliberate visual customization — only panes with custom `pane_border` overrides get their titles restored.

### 2. Save and restore pane border status and format

**Save side** (`save.sh`):
- Extended `dump_windows()` to capture window-level `pane-border-status` and `pane-border-format` as two new tab-delimited fields at the end of each `window` line
- New `dump_pane_borders()` function: queries each pane via `show-options -p` for per-pane overrides and emits `pane_border` lines only when the pane value differs from its window-level setting (actual overrides, not inherited values)

**Restore side** (`restore.sh`):
- Extended `restore_window_properties()` to read and apply window-level `pane-border-status` and `pane-border-format` via `set-option -w`
- New `restore_pane_borders()` function: applies per-pane overrides via `set -p`
- `restore_pane_titles()` preserves the active pane (saves/restores it) around `select-pane -T` to avoid undoing `restore_active_pane_for_each_window()`

### 3. Backward compatibility

Old save files (missing `pane_border` lines and the two extra window fields) are handled gracefully:
- Missing `border_status`/`border_format` fields → `read` assigns empty → skip checks → no-op
- Missing `pane_border` lines → `restore_pane_titles()` builds an empty key set → no titles restored → original behavior
- Missing `pane_border` lines → `restore_pane_borders()` reads nothing → no-op

### 4. Bug fix: `is_line_type()` tab anchor

The `is_line_type()` function used `grep "^pane"` which also matched `pane_border` lines (a new line type). This caused `restore_all_panes()` to feed `pane_border` data into `restore_pane()`, creating fake panes. Fixed by anchoring with a literal tab: `grep "^${line_type}\t"`.

## Related

Similar effort in #342 (c3r34lk1ll3r, 2020) proposed adding pane title save/restore — that feature was subsequently merged via #431 (Hologos). This PR builds on that foundation with border state persistence, post-process title re-application, and backward-compatible format extensions.