### PR TITLE
Preserve empty pane titles during save and restore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+lib/tmux-test/.git

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -176,6 +176,7 @@ new_pane() {
 restore_pane() {
 	local pane="$1"
 	while IFS=$d read line_type session_name window_number window_active window_flags pane_index pane_title dir pane_active pane_command pane_full_command; do
+		pane_title="$(remove_first_char "$pane_title")"
 		dir="$(remove_first_char "$dir")"
 		pane_full_command="$(remove_first_char "$pane_full_command")"
 		if [ "$session_name" == "0" ]; then

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -39,7 +39,7 @@ pane_format() {
 	format+="${delimiter}"
 	format+="#{pane_index}"
 	format+="${delimiter}"
-	format+="#{?pane_title,#{pane_title},_}"
+	format+=":#{pane_title}"
 	format+="${delimiter}"
 	format+=":#{pane_current_path}"
 	format+="${delimiter}"

--- a/scripts/save.sh
+++ b/scripts/save.sh
@@ -39,7 +39,7 @@ pane_format() {
 	format+="${delimiter}"
 	format+="#{pane_index}"
 	format+="${delimiter}"
-	format+="#{pane_title}"
+	format+="#{?pane_title,#{pane_title},_}"
 	format+="${delimiter}"
 	format+=":#{pane_current_path}"
 	format+="${delimiter}"

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
+	&& yes | unminimize \
 	&& apt-get install --yes --no-install-recommends \
 		bash \
 		ca-certificates \
@@ -12,10 +13,12 @@ RUN apt-get update \
 		findutils \
 		git \
 		grep \
+		man-db \
 		procps \
 		sed \
 		tar \
 		tmux \
+		vim \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid 10001 tester \
@@ -27,6 +30,7 @@ USER tester:tester
 WORKDIR /opt/tmux-resurrect-source
 
 ENV HOME=/home/tester
+ENV SHELL=/bin/bash
 ENV TERM=xterm-256color
 
 ENTRYPOINT ["/opt/tmux-resurrect-source/tests/docker/entrypoint"]

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+	&& apt-get install --yes --no-install-recommends \
+		bash \
+		ca-certificates \
+		coreutils \
+		diffutils \
+		expect \
+		findutils \
+		git \
+		grep \
+		procps \
+		sed \
+		tar \
+		tmux \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 10001 tester \
+	&& useradd --uid 10001 --gid 10001 --create-home tester
+
+COPY --chown=tester:tester . /opt/tmux-resurrect-source
+
+USER tester:tester
+WORKDIR /opt/tmux-resurrect-source
+
+ENV HOME=/home/tester
+ENV TERM=xterm-256color
+
+ENTRYPOINT ["/opt/tmux-resurrect-source/tests/docker/entrypoint"]

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -1,0 +1,22 @@
+# Docker integration tests
+
+Run the integration suite with:
+
+```sh
+tests/run_tests_in_docker
+```
+
+Pass test paths to run a subset:
+
+```sh
+tests/run_tests_in_docker tests/test_resurrect_save.sh
+```
+
+The image contains the current source snapshot. Runtime containers mount no
+host paths, have no network, run as UID 10001, and use a read-only root
+filesystem with disposable tmpfs storage.
+
+The host runner labels every container with a unique run ID. Cleanup retains
+the exact container ID returned by `docker create`, verifies that its label
+still matches the run ID, and removes only that ID. It never lists, stops,
+removes, or prunes containers by a broad name or filter.

--- a/tests/docker/entrypoint
+++ b/tests/docker/entrypoint
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -eu
+
+readonly source_dir="/opt/tmux-resurrect-source"
+readonly work_dir="/work/tmux-resurrect"
+
+normalize_source_tree() {
+	mkdir -p "$work_dir"
+	cp -a "$source_dir/." "$work_dir/"
+	rm -rf "$work_dir/.git" "$work_dir/lib/tmux-test/.git"
+}
+
+create_local_repository() {
+	git init --quiet
+	git config user.email "tmux-resurrect-tests@localhost"
+	git config user.name "tmux-resurrect tests"
+	git add --all
+	git commit --quiet --message "Container test source"
+}
+
+run_test_file() {
+	local test_file="$1"
+	mkdir -p "$HOME/.tmux/resurrect"
+	tests/run_tests_in_isolation "$test_file"
+}
+
+run_tests() {
+	local status test_file
+	status=0
+	if [ "$#" -eq 0 ]; then
+		set -- tests/test*.sh
+	fi
+	for test_file in "$@"; do
+		run_test_file "$test_file" || status=1
+	done
+	return "$status"
+}
+
+main() {
+	normalize_source_tree
+	cd "$work_dir"
+	create_local_repository
+	run_tests "$@"
+}
+
+main "$@"

--- a/tests/fixtures/restore_file.txt
+++ b/tests/fixtures/restore_file.txt
@@ -1,15 +1,15 @@
-pane	0	0	1	:*	0	pane-0	:/tmp	1	bash	:
-pane	blue	0	0	:	0	pane-7	:/tmp	1	vim	:vim foo.txt
-pane	blue	1	0	:-	0	pane-8	:/tmp	0	bash	:
-pane	blue	1	0	:-	1	pane-9	:/tmp	1	man	:man echo
-pane	blue	2	1	:*	0	pane-10	:/tmp	1	bash	:
-pane	red	0	0	:	0	pane-1	:/tmp	1	bash	:
-pane	red	1	0	:-Z	0	pane-2	:/tmp	0	bash	:
-pane	red	1	0	:-Z	1	pane-3	:/tmp	0	bash	:
-pane	red	1	0	:-Z	2	pane-4	:/tmp	1	bash	:
-pane	red	2	1	:*	0	pane-5	:/tmp	0	bash	:
-pane	red	2	1	:*	1	pane-6	:/tmp	1	bash	:
-pane	yellow	0	1	:*	0	_	:/tmp/bar	1	bash	:
+pane	0	0	1	:*	0	:pane-0	:/tmp	1	bash	:
+pane	blue	0	0	:	0	:pane-7	:/tmp	1	vim	:vim foo.txt
+pane	blue	1	0	:-	0	:pane-8	:/tmp	0	bash	:
+pane	blue	1	0	:-	1	:pane-9	:/tmp	1	man	:man echo
+pane	blue	2	1	:*	0	:pane-10	:/tmp	1	bash	:
+pane	red	0	0	:	0	:pane-1	:/tmp	1	bash	:
+pane	red	1	0	:-Z	0	:pane-2	:/tmp	0	bash	:
+pane	red	1	0	:-Z	1	:pane-3	:/tmp	0	bash	:
+pane	red	1	0	:-Z	2	:pane-4	:/tmp	1	bash	:
+pane	red	2	1	:*	0	:pane-5	:/tmp	0	bash	:
+pane	red	2	1	:*	1	:pane-6	:/tmp	1	bash	:
+pane	yellow	0	1	:*	0	:	:/tmp/bar	1	bash	:
 window	0	0	:bash	1	:*	ce9e,200x49,0,0,1	:
 window	blue	0	:bash	0	:	ce9f,200x49,0,0,2	:
 window	blue	1	:bash	0	:-	178b,200x49,0,0{100x49,0,0,3,99x49,101,0,4}	:

--- a/tests/fixtures/restore_file.txt
+++ b/tests/fixtures/restore_file.txt
@@ -1,21 +1,21 @@
-pane	0	0	:bash	1	:*	0	:/tmp	1	bash	:
-pane	blue	0	:vim	0	:	0	:/tmp	1	vim	:vim foo.txt
-pane	blue	1	:man	0	:-	0	:/tmp	0	bash	:
-pane	blue	1	:man	0	:-	1	:/usr/share/man	1	man	:man echo
-pane	blue	2	:bash	1	:*	0	:/tmp	1	bash	:
-pane	red	0	:bash	0	:	0	:/tmp	1	bash	:
-pane	red	1	:bash	0	:-Z	0	:/tmp	0	bash	:
-pane	red	1	:bash	0	:-Z	1	:/tmp	0	bash	:
-pane	red	1	:bash	0	:-Z	2	:/tmp	1	bash	:
-pane	red	2	:bash	1	:*	0	:/tmp	0	bash	:
-pane	red	2	:bash	1	:*	1	:/tmp	1	bash	:
-pane	yellow	0	:bash	1	:*	0	:/tmp/bar	1	bash	:
-window	0	0	1	:*	ce9e,200x49,0,0,1
-window	blue	0	0	:	ce9f,200x49,0,0,2
-window	blue	1	0	:-	178b,200x49,0,0{100x49,0,0,3,99x49,101,0,4}
-window	blue	2	1	:*	cea2,200x49,0,0,5
-window	red	0	0	:	cea3,200x49,0,0,6
-window	red	1	0	:-Z	135b,200x49,0,0[200x24,0,0,7,200x24,0,25{100x24,0,25,8,99x24,101,25,9}]
-window	red	2	1	:*	db81,200x49,0,0[200x24,0,0,10,200x24,0,25,11]
-window	yellow	0	1	:*	6781,200x49,0,0,12
+pane	0	0	1	:*	0	pane-0	:/tmp	1	bash	:
+pane	blue	0	0	:	0	pane-7	:/tmp	1	vim	:vim foo.txt
+pane	blue	1	0	:-	0	pane-8	:/tmp	0	bash	:
+pane	blue	1	0	:-	1	pane-9	:/tmp	1	man	:man echo
+pane	blue	2	1	:*	0	pane-10	:/tmp	1	bash	:
+pane	red	0	0	:	0	pane-1	:/tmp	1	bash	:
+pane	red	1	0	:-Z	0	pane-2	:/tmp	0	bash	:
+pane	red	1	0	:-Z	1	pane-3	:/tmp	0	bash	:
+pane	red	1	0	:-Z	2	pane-4	:/tmp	1	bash	:
+pane	red	2	1	:*	0	pane-5	:/tmp	0	bash	:
+pane	red	2	1	:*	1	pane-6	:/tmp	1	bash	:
+pane	yellow	0	1	:*	0	_	:/tmp/bar	1	bash	:
+window	0	0	:bash	1	:*	ce9e,200x49,0,0,1	:
+window	blue	0	:bash	0	:	ce9f,200x49,0,0,2	:
+window	blue	1	:bash	0	:-	178b,200x49,0,0{100x49,0,0,3,99x49,101,0,4}	:
+window	blue	2	:bash	1	:*	cea2,200x49,0,0,5	:
+window	red	0	:bash	0	:	cea3,200x49,0,0,6	:
+window	red	1	:bash	0	:-Z	135b,200x49,0,0[200x24,0,0,7,200x24,0,25{100x24,0,25,8,99x24,101,25,9}]	:
+window	red	2	:bash	1	:*	db81,200x49,0,0[200x24,0,0,10,200x24,0,25,11]	:
+window	yellow	0	:bash	1	:*	6781,200x49,0,0,12	:
 state	yellow	blue

--- a/tests/fixtures/save_file.txt
+++ b/tests/fixtures/save_file.txt
@@ -1,21 +1,21 @@
-pane	0	0	:bash	1	:*	0	:/tmp	1	bash	:
-pane	blue	0	:vim	0	:!	0	:/tmp	1	vim	:vim foo.txt
-pane	blue	1	:man	0	:!-	0	:/tmp	0	bash	:
-pane	blue	1	:man	0	:!-	1	:/usr/share/man	1	man	:man echo
-pane	blue	2	:bash	1	:*	0	:/tmp	1	bash	:
-pane	red	0	:bash	0	:	0	:/tmp	1	bash	:
-pane	red	1	:bash	0	:-Z	0	:/tmp	0	bash	:
-pane	red	1	:bash	0	:-Z	1	:/tmp	0	bash	:
-pane	red	1	:bash	0	:-Z	2	:/tmp	1	bash	:
-pane	red	2	:bash	1	:*	0	:/tmp	0	bash	:
-pane	red	2	:bash	1	:*	1	:/tmp	1	bash	:
-pane	yellow	0	:bash	1	:*	0	:/tmp/bar	1	bash	:
-window	0	0	1	:*	ce9d,200x49,0,0,0
-window	blue	0	0	:!	cea4,200x49,0,0,7
-window	blue	1	0	:!-	9797,200x49,0,0{100x49,0,0,8,99x49,101,0,9}
-window	blue	2	1	:*	677f,200x49,0,0,10
-window	red	0	0	:	ce9e,200x49,0,0,1
-window	red	1	0	:-Z	52b7,200x49,0,0[200x24,0,0,2,200x24,0,25{100x24,0,25,3,99x24,101,25,4}]
-window	red	2	1	:*	bd68,200x49,0,0[200x24,0,0,5,200x24,0,25,6]
-window	yellow	0	1	:*	6780,200x49,0,0,11
+pane	0	0	1	:*	0	pane-0	:/tmp	1	sh	:
+pane	blue	0	0	:	0	pane-7	:/tmp	1	sh	:
+pane	blue	1	0	:-	0	pane-8	:/tmp	0	sh	:
+pane	blue	1	0	:-	1	pane-9	:/tmp	1	sh	:
+pane	blue	2	1	:*	0	pane-10	:/tmp	1	sh	:
+pane	red	0	0	:	0	pane-1	:/tmp	1	sh	:
+pane	red	1	0	:-Z	0	pane-2	:/tmp	0	sh	:
+pane	red	1	0	:-Z	1	pane-3	:/tmp	0	sh	:
+pane	red	1	0	:-Z	2	pane-4	:/tmp	1	sh	:
+pane	red	2	1	:*	0	pane-5	:/tmp	0	sh	:
+pane	red	2	1	:*	1	pane-6	:/tmp	1	sh	:
+pane	yellow	0	1	:*	0	_	:/tmp/bar	1	sh	:
+window	0	0	:sh	1	:*	ae5d,80x23,0,0,0	:
+window	blue	0	:sh	0	:	ae64,80x23,0,0,7	:
+window	blue	1	:sh	0	:-	7125,80x23,0,0{40x23,0,0,8,39x23,41,0,9}	:
+window	blue	2	:sh	1	:*	575f,80x23,0,0,10	:
+window	red	0	:sh	0	:	ae5e,80x23,0,0,1	:
+window	red	1	:sh	0	:-Z	e155,80x23,0,0[80x11,0,0,2,80x11,0,12{40x11,0,12,3,39x11,41,12,4}]	:
+window	red	2	:sh	1	:*	11a8,80x23,0,0[80x11,0,0,5,80x11,0,12,6]	:
+window	yellow	0	:sh	1	:*	5760,80x23,0,0,11	:
 state	yellow	blue

--- a/tests/fixtures/save_file.txt
+++ b/tests/fixtures/save_file.txt
@@ -1,21 +1,21 @@
-pane	0	0	1	:*	0	pane-0	:/tmp	1	sh	:
-pane	blue	0	0	:	0	pane-7	:/tmp	1	sh	:
-pane	blue	1	0	:-	0	pane-8	:/tmp	0	sh	:
-pane	blue	1	0	:-	1	pane-9	:/tmp	1	sh	:
-pane	blue	2	1	:*	0	pane-10	:/tmp	1	sh	:
-pane	red	0	0	:	0	pane-1	:/tmp	1	sh	:
-pane	red	1	0	:-Z	0	pane-2	:/tmp	0	sh	:
-pane	red	1	0	:-Z	1	pane-3	:/tmp	0	sh	:
-pane	red	1	0	:-Z	2	pane-4	:/tmp	1	sh	:
-pane	red	2	1	:*	0	pane-5	:/tmp	0	sh	:
-pane	red	2	1	:*	1	pane-6	:/tmp	1	sh	:
-pane	yellow	0	1	:*	0	_	:/tmp/bar	1	sh	:
-window	0	0	:sh	1	:*	ae5d,80x23,0,0,0	:
-window	blue	0	:sh	0	:	ae64,80x23,0,0,7	:
-window	blue	1	:sh	0	:-	7125,80x23,0,0{40x23,0,0,8,39x23,41,0,9}	:
-window	blue	2	:sh	1	:*	575f,80x23,0,0,10	:
-window	red	0	:sh	0	:	ae5e,80x23,0,0,1	:
-window	red	1	:sh	0	:-Z	e155,80x23,0,0[80x11,0,0,2,80x11,0,12{40x11,0,12,3,39x11,41,12,4}]	:
-window	red	2	:sh	1	:*	11a8,80x23,0,0[80x11,0,0,5,80x11,0,12,6]	:
-window	yellow	0	:sh	1	:*	5760,80x23,0,0,11	:
+pane	0	0	1	:*	0	pane-0	:/tmp	1	bash	:
+pane	blue	0	0	:	0	pane-7	:/tmp	1	vim	:vim foo.txt
+pane	blue	1	0	:-	0	pane-8	:/tmp	0	bash	:
+pane	blue	1	0	:-	1	pane-9	:/tmp	1	man	:man echo
+pane	blue	2	1	:*	0	pane-10	:/tmp	1	bash	:
+pane	red	0	0	:	0	pane-1	:/tmp	1	bash	:
+pane	red	1	0	:-Z	0	pane-2	:/tmp	0	bash	:
+pane	red	1	0	:-Z	1	pane-3	:/tmp	0	bash	:
+pane	red	1	0	:-Z	2	pane-4	:/tmp	1	bash	:
+pane	red	2	1	:*	0	pane-5	:/tmp	0	bash	:
+pane	red	2	1	:*	1	pane-6	:/tmp	1	bash	:
+pane	yellow	0	1	:*	0	_	:/tmp/bar	1	bash	:
+window	0	0	:bash	1	:*	ce9d,200x49,0,0,0	:
+window	blue	0	:bash	0	:	cea4,200x49,0,0,7	:
+window	blue	1	:bash	0	:-	9797,200x49,0,0{100x49,0,0,8,99x49,101,0,9}	:
+window	blue	2	:bash	1	:*	677f,200x49,0,0,10	:
+window	red	0	:bash	0	:	ce9e,200x49,0,0,1	:
+window	red	1	:bash	0	:-Z	52b7,200x49,0,0[200x24,0,0,2,200x24,0,25{100x24,0,25,3,99x24,101,25,4}]	:
+window	red	2	:bash	1	:*	bd68,200x49,0,0[200x24,0,0,5,200x24,0,25,6]	:
+window	yellow	0	:bash	1	:*	6780,200x49,0,0,11	:
 state	yellow	blue

--- a/tests/fixtures/save_file.txt
+++ b/tests/fixtures/save_file.txt
@@ -1,15 +1,15 @@
-pane	0	0	1	:*	0	pane-0	:/tmp	1	bash	:
-pane	blue	0	0	:	0	pane-7	:/tmp	1	vim	:vim foo.txt
-pane	blue	1	0	:-	0	pane-8	:/tmp	0	bash	:
-pane	blue	1	0	:-	1	pane-9	:/tmp	1	man	:man echo
-pane	blue	2	1	:*	0	pane-10	:/tmp	1	bash	:
-pane	red	0	0	:	0	pane-1	:/tmp	1	bash	:
-pane	red	1	0	:-Z	0	pane-2	:/tmp	0	bash	:
-pane	red	1	0	:-Z	1	pane-3	:/tmp	0	bash	:
-pane	red	1	0	:-Z	2	pane-4	:/tmp	1	bash	:
-pane	red	2	1	:*	0	pane-5	:/tmp	0	bash	:
-pane	red	2	1	:*	1	pane-6	:/tmp	1	bash	:
-pane	yellow	0	1	:*	0	_	:/tmp/bar	1	bash	:
+pane	0	0	1	:*	0	:pane-0	:/tmp	1	bash	:
+pane	blue	0	0	:	0	:pane-7	:/tmp	1	vim	:vim foo.txt
+pane	blue	1	0	:-	0	:pane-8	:/tmp	0	bash	:
+pane	blue	1	0	:-	1	:pane-9	:/tmp	1	man	:man echo
+pane	blue	2	1	:*	0	:pane-10	:/tmp	1	bash	:
+pane	red	0	0	:	0	:pane-1	:/tmp	1	bash	:
+pane	red	1	0	:-Z	0	:pane-2	:/tmp	0	bash	:
+pane	red	1	0	:-Z	1	:pane-3	:/tmp	0	bash	:
+pane	red	1	0	:-Z	2	:pane-4	:/tmp	1	bash	:
+pane	red	2	1	:*	0	:pane-5	:/tmp	0	bash	:
+pane	red	2	1	:*	1	:pane-6	:/tmp	1	bash	:
+pane	yellow	0	1	:*	0	:	:/tmp/bar	1	bash	:
 window	0	0	:bash	1	:*	ce9d,200x49,0,0,0	:
 window	blue	0	:bash	0	:	cea4,200x49,0,0,7	:
 window	blue	1	:bash	0	:-	9797,200x49,0,0{100x49,0,0,8,99x49,101,0,9}	:

--- a/tests/helpers/create_and_save_tmux_test_environment.exp
+++ b/tests/helpers/create_and_save_tmux_test_environment.exp
@@ -37,6 +37,13 @@ new_tmux_window
 new_tmux_session "yellow"
 run_shell_command "cd /tmp/bar"
 
+# Make pane titles deterministic and exercise the empty-title regression.
+for {set pane_number 0} {$pane_number <= 11} {incr pane_number} {
+  run_shell_command \
+    "tmux select-pane -t %$pane_number -T pane-$pane_number"
+}
+run_shell_command "tmux select-pane -t %11 -T ''"
+
 start_resurrect_save
 
 run_shell_command "tmux kill-server"

--- a/tests/helpers/resurrect_helpers.sh
+++ b/tests/helpers/resurrect_helpers.sh
@@ -9,3 +9,10 @@ last_save_file_differs_helper() {
 	diff "$original_file" "${HOME}/.tmux/resurrect/last"
 	[ $? -ne 0 ]
 }
+
+configure_tmux_test_environment_helper() {
+	printf '%s\n' \
+		'set-option -g automatic-rename off' \
+		'set-option -g default-shell /bin/bash' \
+		>> "${HOME}/.tmux.conf"
+}

--- a/tests/run_tests_in_docker
+++ b/tests/run_tests_in_docker
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -eu
+
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly current_dir
+repository_dir="$(cd "$current_dir/.." && pwd)"
+readonly repository_dir
+readonly image="tmux-resurrect-tests:local"
+run_id="tmux-resurrect-$(date -u '+%Y%m%dT%H%M%SZ')-$$"
+readonly run_id
+readonly label_key="tmux-resurrect.test-run-id"
+
+container_id=""
+
+build_image() {
+	docker build \
+		--file "$current_dir/docker/Dockerfile" \
+		--tag "$image" \
+		"$repository_dir"
+}
+
+create_container() {
+	container_id="$(docker create \
+		--init \
+		--network none \
+		--read-only \
+		--cap-drop ALL \
+		--security-opt no-new-privileges \
+		--pids-limit 256 \
+		--label "$label_key=$run_id" \
+		--tmpfs \
+			/tmp:rw,exec,nosuid,nodev,mode=1777 \
+		--tmpfs \
+			/work:rw,exec,nosuid,nodev,mode=1777 \
+		--tmpfs \
+			/home/tester:rw,exec,nosuid,nodev,mode=1777 \
+		"$image" "$@")"
+	[ -n "$container_id" ]
+}
+
+container_belongs_to_run() {
+	local actual_run_id
+	actual_run_id="$(docker inspect \
+		--format "{{ index .Config.Labels \"$label_key\" }}" \
+		"$container_id" 2>/dev/null || true)"
+	[ "$actual_run_id" = "$run_id" ]
+}
+
+remove_container() {
+	[ -n "$container_id" ] || return 0
+	if ! container_belongs_to_run; then
+		printf 'Refusing to remove container with unverified ownership: %s\n' \
+			"$container_id" >&2
+		return 1
+	fi
+	docker rm --force "$container_id" >/dev/null
+	container_id=""
+}
+
+forward_signal() {
+	local signal="$1"
+	[ -n "$container_id" ] || return 0
+	container_belongs_to_run || return 1
+	docker kill --signal "$signal" "$container_id" >/dev/null 2>&1 || true
+}
+
+run_container() {
+	docker start --attach "$container_id"
+}
+
+main() {
+	local status
+	trap 'forward_signal INT' INT
+	trap 'forward_signal TERM' TERM
+	trap remove_container EXIT
+	build_image
+	create_container "$@"
+	status=0
+	run_container || status=$?
+	return "$status"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+	main "$@"
+fi

--- a/tests/run_tests_in_docker
+++ b/tests/run_tests_in_docker
@@ -23,6 +23,9 @@ build_image() {
 create_container() {
 	container_id="$(docker create \
 		--init \
+		--name "$run_id" \
+		--hostname tmux-resurrect-test \
+		--tty \
 		--network none \
 		--read-only \
 		--cap-drop ALL \

--- a/tests/test_docker_runner.sh
+++ b/tests/test_docker_runner.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -eu
+
+current_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=run_tests_in_docker
+source "$current_dir/run_tests_in_docker"
+
+DOCKER_INSPECT_LABEL=""
+DOCKER_RM_CALLS=0
+
+docker() {
+	case "$1" in
+		inspect)
+			printf '%s\n' "$DOCKER_INSPECT_LABEL"
+			;;
+		rm)
+			DOCKER_RM_CALLS=$((DOCKER_RM_CALLS + 1))
+			;;
+		*)
+			printf 'Unexpected docker operation in unit test: %s\n' \
+				"$1" >&2
+			return 1
+			;;
+	esac
+}
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	if [ "$expected" = "$actual" ]; then
+		return 0
+	fi
+	printf 'FAIL: %s: expected [%s], got [%s]\n' \
+		"$message" "$expected" "$actual" >&2
+	return 1
+}
+
+test_foreign_container_is_not_removed() {
+	container_id="foreign-container"
+	DOCKER_INSPECT_LABEL="another-run"
+	DOCKER_RM_CALLS=0
+	if remove_container 2>/dev/null; then
+		printf 'FAIL: foreign container removal should be rejected\n' >&2
+		return 1
+	fi
+	assert_equal "0" "$DOCKER_RM_CALLS" \
+		"foreign container remove calls"
+}
+
+test_owned_container_is_removed() {
+	container_id="owned-container"
+	# Defined by the sourced runner; ShellCheck cannot follow the dynamic path.
+	# shellcheck disable=SC2154
+	DOCKER_INSPECT_LABEL="$run_id"
+	DOCKER_RM_CALLS=0
+	remove_container
+	assert_equal "1" "$DOCKER_RM_CALLS" \
+		"owned container remove calls"
+	assert_equal "" "$container_id" \
+		"owned container ID cleared"
+}
+
+main() {
+	test_foreign_container_is_not_removed
+	test_owned_container_is_removed
+	printf 'Docker runner ownership tests passed\n'
+}
+
+main "$@"

--- a/tests/test_resurrect_restore.sh
+++ b/tests/test_resurrect_restore.sh
@@ -22,6 +22,7 @@ restore_tmux_environment_and_save_again() {
 
 main() {
 	install_tmux_plugin_under_test_helper
+	configure_tmux_test_environment_helper
 	setup_before_restore
 	restore_tmux_environment_and_save_again
 

--- a/tests/test_resurrect_save.sh
+++ b/tests/test_resurrect_save.sh
@@ -12,6 +12,7 @@ create_tmux_test_environment_and_save() {
 
 main() {
 	install_tmux_plugin_under_test_helper
+	configure_tmux_test_environment_helper
 	mkdir -p /tmp/bar # setup required dirs
 	create_tmux_test_environment_and_save
 


### PR DESCRIPTION
## Summary

- guard `pane_title` with the same leading `:` used for other optional
  snapshot fields;
- remove that guard during restore, preserving a genuinely empty title;
- add a deterministic Docker regression with one deliberately empty pane
  title and distinct non-empty titles;
- verify both save output and save-after-restore output byte for byte.

When `pane_title` is empty, the current format emits adjacent tabs. Bash
treats tab as IFS whitespace and collapses that empty field, shifting every
later value left. Restore then reads `pane_active` as the directory and opens
the pane in `$HOME` instead of its saved working directory.

The colon guard makes the field non-empty on disk while still restoring the
original empty value.

## Attribution

This uses the lossless approach proposed by @mtkozlowski in #570. That PR was
closed before maintainer review; its author is credited in the implementation
commit. This PR retains that idea and adds automated save/restore regression
coverage in an isolated environment.

## Test environment

The Docker runner has no host mounts or network access, runs as a non-root
user with a read-only root filesystem, and verifies exact container ownership
before cleanup. The pinned environment uses Ubuntu 24.04, tmux 3.4, Bash, and
a 200-by-50 pseudo-terminal.

## Verification

```text
tests/run_tests_in_docker

Docker runner ownership tests passed
test_resurrect_restore.sh: SUCCESS
test_resurrect_save.sh: SUCCESS
```
